### PR TITLE
[Feat] 로컬 알림 구현

### DIFF
--- a/Spha/Spha.xcodeproj/project.pbxproj
+++ b/Spha/Spha.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		B5296CB02CE34B1E00FFE20F /* BreathingPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296CAF2CE34B1E00FFE20F /* BreathingPhase.swift */; };
 		B5296CB22CE34BDB00FFE20F /* TodayStress.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296CB12CE34BDB00FFE20F /* TodayStress.swift */; };
 		B5296CBB2CE3623F00FFE20F /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296CBA2CE3623F00FFE20F /* NotificationManager.swift */; };
+		B5296CD62CE48F6000FFE20F /* NotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296CD52CE48F6000FFE20F /* NotificationView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +70,8 @@
 		B5296CAF2CE34B1E00FFE20F /* BreathingPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingPhase.swift; sourceTree = "<group>"; };
 		B5296CB12CE34BDB00FFE20F /* TodayStress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayStress.swift; sourceTree = "<group>"; };
 		B5296CBA2CE3623F00FFE20F /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
+		B5296CD52CE48F6000FFE20F /* NotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationView.swift; sourceTree = "<group>"; };
+		B5296CD92CE49C3200FFE20F /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -131,6 +134,7 @@
 		B5296C8C2CE2FEC300FFE20F /* SphaWatch Watch App */ = {
 			isa = PBXGroup;
 			children = (
+				B5296CD42CE48F0900FFE20F /* Notification */,
 				B5296C8D2CE2FEC300FFE20F /* SphaWatchApp.swift */,
 				B5296CB92CE3623300FFE20F /* Manager */,
 				B5296CA52CE2FFB200FFE20F /* Views */,
@@ -257,6 +261,15 @@
 			path = Breathing;
 			sourceTree = "<group>";
 		};
+		B5296CD42CE48F0900FFE20F /* Notification */ = {
+			isa = PBXGroup;
+			children = (
+				B5296CD52CE48F6000FFE20F /* NotificationView.swift */,
+				B5296CD92CE49C3200FFE20F /* PushNotificationPayload.apns */,
+			);
+			path = Notification;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -378,6 +391,7 @@
 				B5296CBB2CE3623F00FFE20F /* NotificationManager.swift in Sources */,
 				B5296C902CE2FEC300FFE20F /* ContentView.swift in Sources */,
 				B5296C8E2CE2FEC300FFE20F /* SphaWatchApp.swift in Sources */,
+				B5296CD62CE48F6000FFE20F /* NotificationView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -587,6 +601,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = SphaWatch;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.sophia.Spha;
+				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -617,6 +632,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = SphaWatch;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.sophia.Spha;
+				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Spha/SphaWatch Watch App/Manager/NotificationManager.swift
+++ b/Spha/SphaWatch Watch App/Manager/NotificationManager.swift
@@ -5,4 +5,120 @@
 //  Created by 지영 on 11/12/24.
 //
 
-import Foundation
+import WatchKit
+import UserNotifications
+
+protocol NotificationInterface {
+    func handleStress()
+}
+
+class NotificationManager: NSObject, NotificationInterface {
+    private let notificationCenter = UNUserNotificationCenter.current()
+    
+    override init() {
+        super.init()
+        setupNotifications()
+    }
+    
+    private func setupNotifications() {
+        let openAppAction = UNNotificationAction(
+            identifier: "OPEN_APP",
+            title: "마음 청소하러 가기",
+            options: .foreground
+        )
+        
+        let cancelAction = UNNotificationAction(
+            identifier: "CANCEL",
+            title: "지금 안함",
+            options: .destructive
+        )
+        
+        // 카테고리 설정
+        let hrvCategory = UNNotificationCategory(
+            identifier: "HRV_ALERT",
+            actions: [openAppAction, cancelAction],
+            intentIdentifiers: [],
+            options: []
+        )
+        
+        // 카테고리 등록
+        notificationCenter.setNotificationCategories([hrvCategory])
+        
+        // 알림 권한 요청
+        notificationCenter.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if granted {
+                print("Watch 알림 권한 획득")
+            }
+        }
+        
+        // 델리게이트 설정
+        notificationCenter.delegate = self
+    }
+    
+    func handleStress() {
+        let content = UNMutableNotificationContent()
+        content.title = "Spha"
+        content.body = "마음이 더러워 졌어요\n청소하러 가요"
+        content.sound = .default
+        content.categoryIdentifier = "HRV_ALERT"  // 카테고리 지정
+        
+        WKInterfaceDevice.current().play(.notification)
+        
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: nil
+        )
+        
+        notificationCenter.add(request)
+    }
+}
+
+// 알림 액션 처리를 위한 델리게이트 확장
+extension NotificationManager: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        switch response.actionIdentifier {
+        case "OPEN_APP":
+            print("앱 실행")
+            // TODO: 앱 실행 관련 추가 로직 구현
+        case "CANCEL":
+            print("알림 취소")
+        default:
+            break
+        }
+        
+        completionHandler()
+    }
+    
+    // 앱이 포그라운드 상태일 때 알림을 표시하기 위한 메서드
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
+    }
+}
+
+
+//class HealthKitManager {
+//    private let notificationManager: NotificationManaging
+//    
+//    init(notificationManager: NotificationManaging) {
+//        self.notificationManager = notificationManager
+//    }
+//    
+//    func processHRVUpdate(_ hrvValue: Double) {
+//        if hrvValue < thresholdValue {
+//            #if os(watchOS)
+//            notificationManager.handleLowHRV()
+//            #endif
+//        }
+//    }
+//}
+
+

--- a/Spha/SphaWatch Watch App/Manager/NotificationManager.swift
+++ b/Spha/SphaWatch Watch App/Manager/NotificationManager.swift
@@ -45,9 +45,11 @@ class NotificationManager: NSObject, NotificationInterface {
         notificationCenter.setNotificationCategories([hrvCategory])
         
         // 알림 권한 요청
-        notificationCenter.requestAuthorization(options: [.alert, .sound]) { granted, error in
+        notificationCenter.requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
             if granted {
                 print("Watch 알림 권한 획득")
+            } else if let error = error{
+                print("Error: \(error.localizedDescription))")
             }
         }
         

--- a/Spha/SphaWatch Watch App/Manager/NotificationManager.swift
+++ b/Spha/SphaWatch Watch App/Manager/NotificationManager.swift
@@ -103,22 +103,3 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
         completionHandler([.banner, .sound])
     }
 }
-
-
-//class HealthKitManager {
-//    private let notificationManager: NotificationManaging
-//    
-//    init(notificationManager: NotificationManaging) {
-//        self.notificationManager = notificationManager
-//    }
-//    
-//    func processHRVUpdate(_ hrvValue: Double) {
-//        if hrvValue < thresholdValue {
-//            #if os(watchOS)
-//            notificationManager.handleLowHRV()
-//            #endif
-//        }
-//    }
-//}
-
-

--- a/Spha/SphaWatch Watch App/Notification/NotificationView.swift
+++ b/Spha/SphaWatch Watch App/Notification/NotificationView.swift
@@ -1,0 +1,23 @@
+//
+//  NotificationView.swift
+//  SphaWatch Watch App
+//
+//  Created by 지영 on 11/13/24.
+//
+
+import SwiftUI
+
+struct NotificationView: View {
+    let notiManager = NotificationManager()
+    
+    var body: some View {
+        VStack {
+            Button("테스트 알림") {
+                notiManager.handleStress()
+            }
+        }
+    }
+}
+#Preview {
+    NotificationView()
+}

--- a/Spha/SphaWatch Watch App/Notification/PushNotificationPayload.apns
+++ b/Spha/SphaWatch Watch App/Notification/PushNotificationPayload.apns
@@ -1,0 +1,20 @@
+{
+    "aps": {
+        "alert": {
+            "title": "Optional title",
+            "message": "Optional subtitle"
+        },
+        "category": "HRV_ALERT",
+    },
+    
+    "Simulator Target Bundle": "com.sophia.Spha.watchkitapp"
+    
+    "WatchKit Simulator Actions": [
+        {
+            "title": "First Button",
+            "identifier": "firstButtonAction"
+        }
+    ],
+    
+    "customKey": "Use this file to define a testing payload for your notifications. The aps dictionary specifies the category, alert text and title. The WatchKit Simulator Actions array can provide info for one or more action buttons in addition to the standard Dismiss button. Any other top level keys are custom payload. If you have multiple such JSON files in your project, you'll be able to select them when choosing to debug the notification interface of your Watch App."
+}

--- a/Spha/SphaWatch Watch App/SphaWatchApp.swift
+++ b/Spha/SphaWatch Watch App/SphaWatchApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct SphaWatch_Watch_AppApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            NotificationView()
         }
     }
 }


### PR DESCRIPTION
## 🔥 작업한 내용
- 워치앱에서 로컬 알림을 위한 NotificationManager 구현
- 알림에 '마음 청소하러 가기'와 '지금 안함' 액션 버튼 추가
- 앱이 포그라운드 상태에서도 알림이 표시되도록 구현

## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 추후 HealthKitManager에서 NotificationManager에 직접 의존하지 않도록 NotificationInterface 프로토콜을 만들어 의존성 역전 원칙 적용하였습니다
- 백그라운드 상태일때에 대한 처리가 필요해보입니다


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->

https://github.com/user-attachments/assets/c535fe44-9da8-4e51-b491-8f4d64814601



## 🚨 관련 이슈
- Resolved: #4 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
