### PR TITLE
[Feat] 호흡 세션 뷰 구현

### DIFF
--- a/Spha/Shared/Managers/RouterManager.swift
+++ b/Spha/Shared/Managers/RouterManager.swift
@@ -10,11 +10,16 @@ import SwiftUI
 
 class RouterManager: ObservableObject {
     @Published var path: NavigationPath = NavigationPath()
+
+    // 추가: 상태 업데이트를 위한 Notification 이름
+    static let backToMainNotification = Notification.Name("backToMainNotification")
     
     @ViewBuilder func view(for route: SphaView) -> some View {
         switch route {
         case .mainView:
             MainView()
+        case .breathingMainView:
+            BreathingMainView()
         }
     }
     
@@ -26,13 +31,15 @@ class RouterManager: ObservableObject {
         path.removeLast()
     }
 
-    
     func backToMain() {
         self.path = NavigationPath()
+        // 상태 초기화를 알리는 Notification 전송
+        NotificationCenter.default.post(name: RouterManager.backToMainNotification, object: nil)
         path.append(SphaView.mainView)
     }
 }
 
 enum SphaView: Hashable {
     case mainView
+    case breathingMainView
 }

--- a/Spha/Shared/Managers/RouterManager.swift
+++ b/Spha/Shared/Managers/RouterManager.swift
@@ -20,6 +20,8 @@ class RouterManager: ObservableObject {
             MainView()
         case .breathingMainView:
             BreathingMainView()
+        case .breathingOutroView:
+            BreathingOutroView()
         }
     }
     
@@ -42,4 +44,5 @@ class RouterManager: ObservableObject {
 enum SphaView: Hashable {
     case mainView
     case breathingMainView
+    case breathingOutroView
 }

--- a/Spha/Spha.xcodeproj/project.pbxproj
+++ b/Spha/Spha.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		331A5B8A2CE48FF000E16AE2 /* HealthKitTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331A5B892CE48FF000E16AE2 /* HealthKitTestView.swift */; };
 		464B4EB02CE4905300218B35 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464B4EAF2CE4905300218B35 /* MainView.swift */; };
 		464B4ED32CE4961B00218B35 /* RouterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464B4ED22CE4961B00218B35 /* RouterManager.swift */; };
+		464B4EEA2CE7258900218B35 /* BreathingOutroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464B4EE92CE7258900218B35 /* BreathingOutroView.swift */; };
+		464B4EEC2CE7259000218B35 /* BreathingMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464B4EEB2CE7259000218B35 /* BreathingMainView.swift */; };
 		B5296C7A2CE2FEAC00FFE20F /* SphaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296C792CE2FEAC00FFE20F /* SphaApp.swift */; };
 		B5296C7C2CE2FEAC00FFE20F /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296C7B2CE2FEAC00FFE20F /* ContentView.swift */; };
 		B5296C7E2CE2FEAD00FFE20F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5296C7D2CE2FEAD00FFE20F /* Assets.xcassets */; };
@@ -58,6 +60,8 @@
 		331A5B8C2CE4944700E16AE2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		464B4EAF2CE4905300218B35 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		464B4ED22CE4961B00218B35 /* RouterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterManager.swift; sourceTree = "<group>"; };
+		464B4EE92CE7258900218B35 /* BreathingOutroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingOutroView.swift; sourceTree = "<group>"; };
+		464B4EEB2CE7259000218B35 /* BreathingMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingMainView.swift; sourceTree = "<group>"; };
 		B5296C762CE2FEAC00FFE20F /* Spha.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Spha.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5296C792CE2FEAC00FFE20F /* SphaApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SphaApp.swift; sourceTree = "<group>"; };
 		B5296C7B2CE2FEAC00FFE20F /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -103,6 +107,15 @@
 				331A5B892CE48FF000E16AE2 /* HealthKitTestView.swift */,
 			);
 			path = HealthKitManager;
+			sourceTree = "<group>";
+		};
+		464B4EE62CE7257300218B35 /* Breathing */ = {
+			isa = PBXGroup;
+			children = (
+				464B4EE92CE7258900218B35 /* BreathingOutroView.swift */,
+				464B4EEB2CE7259000218B35 /* BreathingMainView.swift */,
+			);
+			path = Breathing;
 			sourceTree = "<group>";
 		};
 		B5296C6D2CE2FEAC00FFE20F = {
@@ -206,8 +219,8 @@
 		B5296CA42CE2FF8900FFE20F /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				464B4EE62CE7257300218B35 /* Breathing */,
 				B5296CC12CE3628F00FFE20F /* Statistics */,
-				B5296CC02CE3628600FFE20F /* Breathing */,
 				B5296CBF2CE3628000FFE20F /* Home */,
 				B5296CBE2CE3627800FFE20F /* Onboarding */,
 				B5296C7B2CE2FEAC00FFE20F /* ContentView.swift */,
@@ -246,13 +259,6 @@
 				464B4EAF2CE4905300218B35 /* MainView.swift */,
 			);
 			path = Home;
-			sourceTree = "<group>";
-		};
-		B5296CC02CE3628600FFE20F /* Breathing */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Breathing;
 			sourceTree = "<group>";
 		};
 		B5296CC12CE3628F00FFE20F /* Statistics */ = {
@@ -389,6 +395,7 @@
 			files = (
 				B5296CAA2CE3005800FFE20F /* StressLevel.swift in Sources */,
 				464B4ED32CE4961B00218B35 /* RouterManager.swift in Sources */,
+				464B4EEC2CE7259000218B35 /* BreathingMainView.swift in Sources */,
 				464B4EB02CE4905300218B35 /* MainView.swift in Sources */,
 				B5296CB22CE34BDB00FFE20F /* TodayStress.swift in Sources */,
 				B5296C7C2CE2FEAC00FFE20F /* ContentView.swift in Sources */,
@@ -397,6 +404,7 @@
 				B5296C7A2CE2FEAC00FFE20F /* SphaApp.swift in Sources */,
 				B5296CA82CE3002700FFE20F /* HealthKitManager.swift in Sources */,
 				B5296CB02CE34B1E00FFE20F /* BreathingPhase.swift in Sources */,
+				464B4EEA2CE7258900218B35 /* BreathingOutroView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Spha/Spha.xcodeproj/project.pbxproj
+++ b/Spha/Spha.xcodeproj/project.pbxproj
@@ -60,8 +60,14 @@
 		331A5B8C2CE4944700E16AE2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		464B4EAF2CE4905300218B35 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		464B4ED22CE4961B00218B35 /* RouterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterManager.swift; sourceTree = "<group>"; };
+<<<<<<< HEAD
 		464B4EE92CE7258900218B35 /* BreathingOutroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingOutroView.swift; sourceTree = "<group>"; };
 		464B4EEB2CE7259000218B35 /* BreathingMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingMainView.swift; sourceTree = "<group>"; };
+=======
+		464B4EDE2CE5BCE600218B35 /* BreathingOutroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BreathingOutroView.swift; path = Spha/Views/BreathingOutroView.swift; sourceTree = SOURCE_ROOT; };
+		464B4EE02CE5DA3500218B35 /* BreathingMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BreathingMainView.swift; path = Spha/Views/BreathingMainView.swift; sourceTree = SOURCE_ROOT; };
+		464B4EE22CE7214500218B35 /* BreathingIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BreathingIntroView.swift; path = Spha/Views/BreathingIntroView.swift; sourceTree = SOURCE_ROOT; };
+>>>>>>> 03ab9483fa7dcf9992c4d9dd56127739734fcba6
 		B5296C762CE2FEAC00FFE20F /* Spha.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Spha.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5296C792CE2FEAC00FFE20F /* SphaApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SphaApp.swift; sourceTree = "<group>"; };
 		B5296C7B2CE2FEAC00FFE20F /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -100,6 +106,7 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+<<<<<<< HEAD
 		331A5B8B2CE48FF500E16AE2 /* HealthKitManager */ = {
 			isa = PBXGroup;
 			children = (
@@ -114,6 +121,14 @@
 			children = (
 				464B4EE92CE7258900218B35 /* BreathingOutroView.swift */,
 				464B4EEB2CE7259000218B35 /* BreathingMainView.swift */,
+=======
+		464B4ED92CE5BCBB00218B35 /* Breathing */ = {
+			isa = PBXGroup;
+			children = (
+				464B4EE22CE7214500218B35 /* BreathingIntroView.swift */,
+				464B4EDE2CE5BCE600218B35 /* BreathingOutroView.swift */,
+				464B4EE02CE5DA3500218B35 /* BreathingMainView.swift */,
+>>>>>>> 03ab9483fa7dcf9992c4d9dd56127739734fcba6
 			);
 			path = Breathing;
 			sourceTree = "<group>";
@@ -219,7 +234,11 @@
 		B5296CA42CE2FF8900FFE20F /* Views */ = {
 			isa = PBXGroup;
 			children = (
+<<<<<<< HEAD
 				464B4EE62CE7257300218B35 /* Breathing */,
+=======
+				464B4ED92CE5BCBB00218B35 /* Breathing */,
+>>>>>>> 03ab9483fa7dcf9992c4d9dd56127739734fcba6
 				B5296CC12CE3628F00FFE20F /* Statistics */,
 				B5296CBF2CE3628000FFE20F /* Home */,
 				B5296CBE2CE3627800FFE20F /* Onboarding */,
@@ -394,10 +413,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				B5296CAA2CE3005800FFE20F /* StressLevel.swift in Sources */,
+				464B4EDF2CE5BCE600218B35 /* BreathingOutroView.swift in Sources */,
+				464B4EE32CE7214500218B35 /* BreathingIntroView.swift in Sources */,
 				464B4ED32CE4961B00218B35 /* RouterManager.swift in Sources */,
 				464B4EEC2CE7259000218B35 /* BreathingMainView.swift in Sources */,
 				464B4EB02CE4905300218B35 /* MainView.swift in Sources */,
 				B5296CB22CE34BDB00FFE20F /* TodayStress.swift in Sources */,
+				464B4EE12CE5DA3500218B35 /* BreathingMainView.swift in Sources */,
 				B5296C7C2CE2FEAC00FFE20F /* ContentView.swift in Sources */,
 				331A5B8A2CE48FF000E16AE2 /* HealthKitTestView.swift in Sources */,
 				B5296CAE2CE3009900FFE20F /* HealthKitManager+iOS.swift in Sources */,

--- a/Spha/Spha/Views/Breathing/BreathingIntroView.swift
+++ b/Spha/Spha/Views/Breathing/BreathingIntroView.swift
@@ -1,0 +1,30 @@
+//
+//  BreathingIntroView.swift
+//  Spha
+//
+//  Created by 추서연 on 11/15/24.
+//
+import SwiftUI
+
+struct BreathingIntroView: View, IntroOutroEffect {
+    @EnvironmentObject var router: RouterManager
+    @State private var opacity: Double = 0.0
+
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("BreathingIntroView")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.blue)
+        .opacity(opacity)
+        .onAppear {
+            startEffect()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                router.push(view: .breathingMainView)
+            }
+        }
+    }
+}

--- a/Spha/Spha/Views/Breathing/BreathingMainView.swift
+++ b/Spha/Spha/Views/Breathing/BreathingMainView.swift
@@ -4,18 +4,30 @@
 //
 //  Created by 추서연 on 11/15/24.
 //
-
 import SwiftUI
 
 struct BreathingMainView: View {
     @EnvironmentObject var router: RouterManager
+    @State private var currentPhase: BreathingPhase? = nil
+    @State private var phaseText: String = "마음청소를 시작할게요"
+    @State private var showText: Bool = true
 
     var body: some View {
         VStack {
+            // 호흡 단계에 맞는 이미지 (필요시 교체 가능)
             Image(systemName: "globe")
                 .imageScale(.large)
                 .foregroundStyle(.tint)
-            Text("BreathingMainView")
+            
+            // 호흡 단계 텍스트
+            if showText {
+                Text(phaseText)
+                    .font(.title)
+                    .padding()
+                    .transition(.opacity)
+            }
+            
+            Spacer()
         }
         .navigationBarBackButtonHidden(true)
         .toolbar {
@@ -28,9 +40,67 @@ struct BreathingMainView: View {
                 }
             }
         }
+        .onAppear {
+            startBreathingIntro()
+        }
+    }
+    
+    // 호흡 준비 시작 - 첫 번째와 두 번째 멘트
+    private func startBreathingIntro() {
+        // 첫 번째 텍스트 단계 - 마음청소
+        phaseText = "마음청소를 시작할게요"
+        withAnimation {
+            showText = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            withAnimation {
+                showText = false
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                // 두 번째 텍스트 단계 - 호흡에 집중
+                phaseText = "호흡에 집중하세요"
+                withAnimation {
+                    showText = true
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                    withAnimation {
+                        showText = false
+                    }
+                    startBreathingPhase()
+                }
+            }
+        }
+    }
+    
+    // 호흡 단계 시작 (inhale, hold, exhale)
+    private func startBreathingPhase() {
+        // 호흡 단계 시작
+        currentPhase = .inhale
+        phaseText = "숨을 들이 쉬세요"
+        showText = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            currentPhase = .hold
+            phaseText = "잠시 멈추세요"
+            DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                currentPhase = .exhale
+                phaseText = "숨을 내쉬세요"
+                DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                    currentPhase = .hold
+                    phaseText = "잠시 멈추세요"
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                        finishBreathing()
+                    }
+                }
+            }
+        }
+    }
+    
+    // 호흡이 끝났을 때 메시지 표시
+    private func finishBreathing() {
+        phaseText = "호흡 끝"
+        showText = true
     }
 }
-
 
 #Preview {
     BreathingMainView()

--- a/Spha/Spha/Views/Breathing/BreathingMainView.swift
+++ b/Spha/Spha/Views/Breathing/BreathingMainView.swift
@@ -1,0 +1,37 @@
+//
+//  BreathingMainView.swift
+//  Spha
+//
+//  Created by 추서연 on 11/15/24.
+//
+
+import SwiftUI
+
+struct BreathingMainView: View {
+    @EnvironmentObject var router: RouterManager
+
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("BreathingMainView")
+        }
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(action: {
+                    router.backToMain() // MainView로 돌아가며 상태 초기화
+                }) {
+                    Image(systemName: "xmark")
+                        .foregroundColor(.blue)
+                }
+            }
+        }
+    }
+}
+
+
+#Preview {
+    BreathingMainView()
+}

--- a/Spha/Spha/Views/Breathing/BreathingMainView.swift
+++ b/Spha/Spha/Views/Breathing/BreathingMainView.swift
@@ -148,11 +148,11 @@ struct BreathingMainView: View {
         }
     }
     
-    // 호흡이 끝났을 때 메시지 표시
+    // 호흡이 끝났을 때 Outro로 전환
     private func finishBreathing() {
-        phaseText = "호흡이 끝났습니다!"
-        showText = true
-        showTimer = false
+        withAnimation {
+            router.push(view: .breathingOutroView) // Outro로 라우팅
+        }
     }
 }
 

--- a/Spha/Spha/Views/Breathing/BreathingOutroView.swift
+++ b/Spha/Spha/Views/Breathing/BreathingOutroView.swift
@@ -1,0 +1,23 @@
+//
+//  BreathingOutroView.swift
+//  Spha
+//
+//  Created by 추서연 on 11/15/24.
+//
+
+import SwiftUI
+struct BreathingOutroView: View {
+    @EnvironmentObject var router: RouterManager
+    
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("BreathingIntroView")
+        }
+    }
+}
+#Preview {
+    BreathingOutroView()
+}

--- a/Spha/Spha/Views/Breathing/BreathingOutroView.swift
+++ b/Spha/Spha/Views/Breathing/BreathingOutroView.swift
@@ -6,18 +6,51 @@
 //
 
 import SwiftUI
+
 struct BreathingOutroView: View {
     @EnvironmentObject var router: RouterManager
-    
+    @State private var fadeOpacity: Double = 1.0 // 초기 값 1.0 (완전 불투명)
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("BreathingIntroView")
+        ZStack {
+            // MainView가 보이는 배경
+            router.view(for: .mainView)
+
+            // BreathingOutroView 오버레이
+            VStack {
+                Image(systemName: "checkmark.circle")
+                    .resizable()
+                    .frame(width: 100, height: 100)
+                    .foregroundColor(.green)
+                Text("호흡이 끝났습니다")
+                    .font(.title)
+                    .padding()
+            }
+            .opacity(fadeOpacity) // 투명도 제어
+            .background(Color.white.opacity(fadeOpacity)) // 배경 포함
+        }
+        .onAppear {
+            startFadeOut()
+        }
+    }
+
+    private func startFadeOut() {
+        // 1초 후 페이드 아웃
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            withAnimation(.easeOut(duration: 1)) {
+                fadeOpacity = 0.0 // 투명도 변경
+            }
+            // 페이드 아웃이 완료된 후 MainView로 상태 유지
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                router.backToMain()
+            }
         }
     }
 }
+
 #Preview {
     BreathingOutroView()
+        .environmentObject(RouterManager())
 }
+
+

--- a/Spha/Spha/Views/Breathing/IntroOutroEffect.swift
+++ b/Spha/Spha/Views/Breathing/IntroOutroEffect.swift
@@ -1,0 +1,28 @@
+//
+//  IntroOutroEffect.swift
+//  Spha
+//
+//  Created by 추서연 on 11/15/24.
+//
+
+import SwiftUI
+
+protocol IntroOutroEffect: View {
+    var opacity: Double { get set }
+    func startEffect()
+    func resetEffect()
+}
+
+extension IntroOutroEffect {
+    mutating func startEffect() {
+        withAnimation(.easeIn(duration: 1.0)) {
+            opacity = 1.0
+        }
+    }
+
+    mutating func resetEffect() {
+        withAnimation(.easeOut(duration: 1.0)) {
+            opacity = 0.0
+        }
+    }
+}

--- a/Spha/Spha/Views/BreathingIntroVIew.swift
+++ b/Spha/Spha/Views/BreathingIntroVIew.swift
@@ -1,0 +1,32 @@
+//
+//  BreathingIntroView.swift
+//  Spha
+//
+//  Created by 추서연 on 11/15/24.
+//
+
+import SwiftUI
+
+struct BreathingIntroView: View {
+    @EnvironmentObject var router: RouterManager
+    @State private var opacity: Double = 0.0
+    
+    var body: some View {
+        VStack {
+            Text("Breathing Intro")
+                .opacity(opacity)
+                .onAppear {
+                    withAnimation(.easeIn(duration: 1.0)) {
+                        opacity = 1.0
+                    }
+                    // 일정 시간 후 BreathingMainView로 자동 전환
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        router.push(view: .breathingMainView)
+                    }
+                }
+        }
+    }
+
+#Preview {
+    BreathingIntroView()
+}

--- a/Spha/Spha/Views/BreathingMainView.swift
+++ b/Spha/Spha/Views/BreathingMainView.swift
@@ -1,0 +1,26 @@
+//
+//  BreathingMainView.swift
+//  Spha
+//
+//  Created by 추서연 on 11/14/24.
+//
+
+import SwiftUI
+
+struct BreathingMainView: View {
+    @EnvironmentObject var router: RouterManager
+    
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("BreathingMainView")
+            
+        }
+    }
+}
+
+#Preview {
+    BreathingMainView()
+}

--- a/Spha/Spha/Views/BreathingOutroView.swift
+++ b/Spha/Spha/Views/BreathingOutroView.swift
@@ -1,0 +1,26 @@
+//
+//  BreathingOutroView.swift
+//  Spha
+//
+//  Created by 추서연 on 11/14/24.
+//
+
+import SwiftUI
+
+struct BreathingOutroView: View {
+    @EnvironmentObject var router: RouterManager
+    
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("BreathingIntroView")
+            
+        }
+    }
+}
+
+#Preview {
+    BreathingOutroView()
+}

--- a/Spha/Spha/Views/Home/MainView.swift
+++ b/Spha/Spha/Views/Home/MainView.swift
@@ -9,18 +9,70 @@ import SwiftUI
 
 struct MainView: View {
     @EnvironmentObject var router: RouterManager
-    
+    @State private var showBreathingIntro = false
+    @State private var breathingIntroOpacity: Double = 0.0
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("여기는 메인뷰")
+        ZStack {
+            // 메인 뷰
+            VStack {
+                Image(systemName: "globe")
+                    .imageScale(.large)
+                    .foregroundStyle(.tint)
+                Text("여기는 메인뷰")
+                
+                Button("Start Breathing") {
+                    startBreathingIntro()
+                }
+            }.navigationBarBackButtonHidden(true)
             
+            // BreathingIntroView 오버레이 뷰
+            if showBreathingIntro {
+                VStack {
+                    Image(systemName: "globe")
+                        .imageScale(.large)
+                        .foregroundStyle(.tint)
+                    Text("BreathingIntroView")
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.blue)
+                .opacity(breathingIntroOpacity) // 페이드인 효과
+                .onAppear {
+                    withAnimation(.easeIn(duration: 1.0)) {
+                        breathingIntroOpacity = 1.0
+                    }
+                    // 일정 시간 후 다른 화면으로 이동
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        router.push(view: .breathingMainView)
+                    }
+                }
+            }
         }
+        .onAppear {
+            // Notification을 관찰하여 상태 초기화
+            NotificationCenter.default.addObserver(forName: RouterManager.backToMainNotification, object: nil, queue: .main) { _ in
+                resetBreathingIntro()
+            }
+        }
+        .onDisappear {
+            NotificationCenter.default.removeObserver(self, name: RouterManager.backToMainNotification, object: nil)
+        }
+    }
+    
+    // BreathingIntroView 상태 초기화 및 페이드인
+    private func resetBreathingIntro() {
+        showBreathingIntro = false
+        breathingIntroOpacity = 0.0
+    }
+    
+    // BreathingIntroView 시작
+    private func startBreathingIntro() {
+        showBreathingIntro = true
+        breathingIntroOpacity = 0.0 // 초기화
     }
 }
 
 #Preview {
     MainView()
 }
+


### PR DESCRIPTION
## 🔥 작업한 내용
- **`BreathingIntroView`에 fade-in 애니메이션** 추가:
  - `VStack` 전체에 `opacity`를 적용하여, 뷰가 처음 나타날 때 부드럽게 `fade-in` 애니메이션을 실행하도록 설정
  - `onAppear`에서 1초 동안 애니메이션 후 자동으로 `BreathingMainView`로 라우팅
- **`BreathingOutroView`에서 페이드 아웃 후 MainView로 라우팅**:
  - `BreathingOutroView`가 1초 후 점차 사라지면서 `MainView`로 돌아가도록 설정
  - 라우터를 통해 `BreathingOutroView`에서 `MainView`로의 원활한 전환을 구현
- **타이머 기반 호흡 세션 구현**:
  - 타이머를 사용하여 호흡 세션에 맞춰 각 단계별로 호흡을 안내하는 동작을 추가
  - 각 호흡 단계에 맞춰 **동그라미 색상 변화**: 첫 번째 숨을 들이마시면 첫 번째 동그라미가 검정색, 두 번째 숨을 들이마시면 두 번째 동그라미가 검정색 등
  - 호흡 세션 종료 후 자동으로 `BreathingOutroView`로 전환되도록 설정




## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- **타이머와 호흡 세션 관리**: 타이머 기반으로 동작을 정확하게 구현했는지, 또는 더 나은 방법이 있을지 피드백을 받고 싶습니다.

- **애니메이션 최적화**: `fade-in` 애니메이션의 뷰 분리가 필요한지 궁금합니다.  
  현재 호흡 세션 시작은 `MainView`에서 `IntroView` overlay `fade-in`을 통해 이루어지고, 종료는 호흡 세션 종료 후 `OutroView` 이동 이후 `MainView` overlay `fade-out` 단계로 진행됩니다.  
  뷰 분리 없이 `MainView` 내에서 `IntroView` overlay 방식이 아닌, 뷰 분리를 통해 뷰 자체의 `opacity`를 조절하여 overlay `fade-in`을 구현할 수 있는지에 대한 피드백을 부탁드립니다!




## 🔧 TODO 
- **호흡 세션 상태 관리**: 타이머와 호흡 세션을 관리할 `BreathingSessionManager` 클래스를 구현하여 호흡 단계 및 타이머를 관리할 수 있도록 해야 합니다. 앞으로의 watch 구현 및 모듈화를 위해 호흡 타이머와 각 단계를 관리하는 클래스가 필요합니다.
- 타이머와 호흡 단계가 정확히 맞춰져야 하며, 애니메이션이 원활하게 진행되는지 확인 중입니다.
- 호흡이 끝난 후 **`BreathingOutroView`로의 전환**이 자연스러운지 추가 테스트가 필요합니다.

## 🗺️ 라우터 매니저 쉽게 쓰기!
### 1. `SphaView` Enum에 뷰 추가하기
- `SphaView`는 **앱 내에서 사용할 뷰**를 정의. 원하는 뷰를 추가한 후, `view(for:)` 메서드에서 해당 뷰를 처리하는 로직을 작성해야 합니다.

  예를 들어, `ExampleView`를 추가하고 싶다면, 아래와 같이 `SphaView`와 `view(for:)` 메서드를 수정합니다:
  
  ```swift
  enum SphaView: Hashable {
      case mainView
      case breathingIntroView
      case breathingMainView
      case exampleView // 새로운 뷰 추가
  }

  @ViewBuilder func view(for route: SphaView) -> some View {
      switch route {
      case .mainView:
          MainView()
      case .breathingIntroView:
          BreathingIntroView()
      case .breathingMainView:
          BreathingMainView()
      case .exampleView: // 추가된 뷰 처리
          ExampleView()
      }
  }
  
### 2. 뷰 전환 트리거

뷰 전환은 `RouterManager` 클래스에서 제공하는 `push(view:)` 메서드를 사용하여 처리합니다. 이 메서드는 주어진 뷰를 **네비게이션 스택에 추가**하여 해당 뷰로 화면을 전환시킵니다. 

뷰 전환 트리거를 통해 뷰가 전환되도록 할 수 있습니다.

예시) 버튼을 클릭하여  `ExampleView` 로 전환
```
Button("Start Breathing Example") {
    router.push(view: .exampleView) // 버튼 클릭 시 ExampleView로 전환
}
```

### 3. backToMain
backToMain() 메서드는 RouterManager에서 모든 뷰를 초기화하고, mainView로 돌아가는 함수입니다. 이 메서드를 호출하면, 현재 뷰를 모두 팝한 후 메인 화면으로 돌아갑니다.
예시) 1초 뒤  `MainView` 로 전환
`DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                router.backToMain()
            }`

- **push(view:)**:  주어진 뷰를 네비게이션 스택에 추가하고 화면에 전환하기
- **pop()**:  현재 화면을 스택에서 제거하고 이전 화면으로 돌아가기
- **backToMain()**:  모든 뷰를 초기화하고 메인 화면으로 돌아가기




## 📸 스크린샷

|    | iOS 호흡 인트로 페이드인 효과 | iOS 호흡 타이머 및 카운팅 구현 및 페이드 아웃 |
|-------|--------------------------------|-------------------------------------------|
| commit id | 0c5ab69 | 77e5a08, 0962147, 2821c4d |
| 이미지 | <img src="https://github.com/user-attachments/assets/9aa97ec7-b169-46ec-add7-945f0267088e" width="250"/> | <img src="https://github.com/user-attachments/assets/c4b28bdc-fac9-458f-8880-a969bd92ff43" width="250"/>




## 🚨 관련 이슈
- Resolved: #6 
