### PR TITLE
[Chore] 호흡 세션 뷰 모델 분리

### DIFF
--- a/Spha/Shared/Managers/BreathingManager.swift
+++ b/Spha/Shared/Managers/BreathingManager.swift
@@ -1,0 +1,21 @@
+//
+//  BreathingManager.swift
+//  Spha
+//
+//  Created by 추서연 on 11/21/24.
+//
+
+import Foundation
+
+// Breathing 단계 관리 프로토콜
+protocol BreathingManager: ObservableObject {
+    var phaseText: String { get set } // 현재 단계 텍스트
+    var showText: Bool { get set }   // 텍스트 표시 여부
+    var timerCount: Int { get set }  // 남은 타이머 시간
+    var showTimer: Bool { get set }  // 타이머 표시 여부
+    var activeCircle: Int { get set } // 활성화된 동그라미 (0~3)
+
+    func startBreathingIntro() // 초기 인트로 시작
+    func startBreathingCycle() // 호흡 사이클 시작
+    func startPhase(phase: BreathingPhase, duration: Int, text: String, completion: @escaping () -> Void) // 특정 호흡 단계 시작
+}

--- a/Spha/Shared/Managers/BreathingManager.swift
+++ b/Spha/Shared/Managers/BreathingManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 // Breathing 단계 관리 프로토콜
-protocol BreathingManager: ObservableObject {
+protocol BreathingManager : ObservableObject {
     var phaseText: String { get set } // 현재 단계 텍스트
     var showText: Bool { get set }   // 텍스트 표시 여부
     var timerCount: Int { get set }  // 남은 타이머 시간

--- a/Spha/Spha.xcodeproj/project.pbxproj
+++ b/Spha/Spha.xcodeproj/project.pbxproj
@@ -23,6 +23,10 @@
 		339C2D2C2CEB961200F1EE00 /* MindfulSessionTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339C2D2B2CEB961200F1EE00 /* MindfulSessionTestView.swift */; };
 		33ADDFF02CEDC68400513149 /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33ADDFEF2CEDC68400513149 /* Color+.swift */; };
 		33ADDFF22CEDC6AE00513149 /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33ADDFF12CEDC6AE00513149 /* Font+.swift */; };
+		460BCEDC2CEE706A0018927C /* BreathingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEDB2CEE706A0018927C /* BreathingManager.swift */; };
+		460BCEDD2CEE70830018927C /* BreathingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEDB2CEE706A0018927C /* BreathingManager.swift */; };
+		460BCEDF2CEE708D0018927C /* BreathingMainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEDE2CEE708D0018927C /* BreathingMainViewModel.swift */; };
+		460BCEE12CEE70B00018927C /* WatchBreathingMainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEE02CEE70B00018927C /* WatchBreathingMainViewModel.swift */; };
 		464B4EB02CE4905300218B35 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464B4EAF2CE4905300218B35 /* MainView.swift */; };
 		464B4ED32CE4961B00218B35 /* RouterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464B4ED22CE4961B00218B35 /* RouterManager.swift */; };
 		4667B0722CE7EA9000F58DB3 /* BreathingMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4667B0712CE7EA9000F58DB3 /* BreathingMainView.swift */; };
@@ -101,6 +105,9 @@
 		33ADDFEE2CEDC67100513149 /* AppleSDGothicNeoSB.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = AppleSDGothicNeoSB.ttf; sourceTree = "<group>"; };
 		33ADDFEF2CEDC68400513149 /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
 		33ADDFF12CEDC6AE00513149 /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
+		460BCEDB2CEE706A0018927C /* BreathingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingManager.swift; sourceTree = "<group>"; };
+		460BCEDE2CEE708D0018927C /* BreathingMainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingMainViewModel.swift; sourceTree = "<group>"; };
+		460BCEE02CEE70B00018927C /* WatchBreathingMainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchBreathingMainViewModel.swift; sourceTree = "<group>"; };
 		464B4EAF2CE4905300218B35 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		464B4ED22CE4961B00218B35 /* RouterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterManager.swift; sourceTree = "<group>"; };
 		4667B0712CE7EA9000F58DB3 /* BreathingMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingMainView.swift; sourceTree = "<group>"; };
@@ -232,6 +239,7 @@
 			isa = PBXGroup;
 			children = (
 				4667B0712CE7EA9000F58DB3 /* BreathingMainView.swift */,
+				460BCEDE2CEE708D0018927C /* BreathingMainViewModel.swift */,
 				4667B0732CE7EA9C00F58DB3 /* BreathingOutroView.swift */,
 			);
 			path = Breathing;
@@ -243,6 +251,7 @@
 				4667B09B2CED011B00F58DB3 /* WatchBreathingOutroView.swift */,
 				4667B0872CECB16600F58DB3 /* WatchBreathingSelectionView.swift */,
 				4667B0892CECBA5900F58DB3 /* WatchBreathingMainView.swift */,
+				460BCEE02CEE70B00018927C /* WatchBreathingMainViewModel.swift */,
 				4667B08D2CECC7FE00F58DB3 /* WatchBreathingExitView.swift */,
 			);
 			path = Breathing;
@@ -344,6 +353,7 @@
 				339C2D262CEB8D7800F1EE00 /* MindfulSessionManager */,
 				331A5B8B2CE48FF500E16AE2 /* HealthKitManager */,
 				464B4ED22CE4961B00218B35 /* RouterManager.swift */,
+				460BCEDB2CEE706A0018927C /* BreathingManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -557,12 +567,14 @@
 				B5296C7C2CE2FEAC00FFE20F /* ContentView.swift in Sources */,
 				334D95D02CEE0D1A007600D7 /* MP4PlayerView.swift in Sources */,
 				339C2D242CEB742300F1EE00 /* HealthKitManager+TestData.swift in Sources */,
+				460BCEDC2CEE706A0018927C /* BreathingManager.swift in Sources */,
 				33ADDFF22CEDC6AE00513149 /* Font+.swift in Sources */,
 				339C2D282CEB8D8F00F1EE00 /* MindfulSessionManager.swift in Sources */,
 				B5296CAE2CE3009900FFE20F /* HealthKitManager+iOS.swift in Sources */,
 				4667B0722CE7EA9000F58DB3 /* BreathingMainView.swift in Sources */,
 				B5296C7A2CE2FEAC00FFE20F /* SphaApp.swift in Sources */,
 				B5296D252CEBA4B300FFE20F /* Date+.swift in Sources */,
+				460BCEDF2CEE708D0018927C /* BreathingMainViewModel.swift in Sources */,
 				B5296CA82CE3002700FFE20F /* HealthKitManager.swift in Sources */,
 				B5296D222CEBA4A100FFE20F /* DailyStatisticsView.swift in Sources */,
 				B5296CB02CE34B1E00FFE20F /* BreathingPhase.swift in Sources */,
@@ -580,9 +592,11 @@
 				4667B08A2CECBA5900F58DB3 /* WatchBreathingMainView.swift in Sources */,
 				B5296C8E2CE2FEC300FFE20F /* SphaWatchApp.swift in Sources */,
 				B5296CD62CE48F6000FFE20F /* NotificationView.swift in Sources */,
+				460BCEE12CEE70B00018927C /* WatchBreathingMainViewModel.swift in Sources */,
 				4667B09C2CED011B00F58DB3 /* WatchBreathingOutroView.swift in Sources */,
 				4667B0822CECB14000F58DB3 /* WatchRouterManager.swift in Sources */,
 				4667B08E2CECC7FE00F58DB3 /* WatchBreathingExitView.swift in Sources */,
+				460BCEDD2CEE70830018927C /* BreathingManager.swift in Sources */,
 				4667B09D2CED015500F58DB3 /* BreathingPhase.swift in Sources */,
 				4667B0862CECB15900F58DB3 /* WatchMainView.swift in Sources */,
 				4667B0882CECB16600F58DB3 /* WatchBreathingSelectionView.swift in Sources */,
@@ -807,7 +821,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SphaWatch Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = 6FFZZTFJHB;
+				DEVELOPMENT_TEAM = 5GCYZU3KDQ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = SphaWatch;
@@ -838,7 +852,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SphaWatch Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = 6FFZZTFJHB;
+				DEVELOPMENT_TEAM = 5GCYZU3KDQ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = SphaWatch;

--- a/Spha/Spha/Views/Breathing/BreathingMainView.swift
+++ b/Spha/Spha/Views/Breathing/BreathingMainView.swift
@@ -9,153 +9,41 @@ import SwiftUI
 
 struct BreathingMainView: View {
     @EnvironmentObject var router: RouterManager
-    @State private var currentPhase: BreathingPhase? = nil
-    @State private var phaseText: String = "마음청소를 시작할게요"
-    @State private var showText: Bool = true
-    @State private var timerCount: Int = 0 // 타이머 값
-    @State private var showTimer: Bool = false // 타이머 표시 여부
-    @State private var activeCircle: Int = 0 // 현재 활성화된 동그라미 (0~3)
-
+    @StateObject private var viewModel = BreathingMainViewModel()
+    
     var body: some View {
         VStack {
-            // 호흡 단계에 맞는 이미지 (필요시 교체 가능)
             Image(systemName: "globe")
                 .imageScale(.large)
                 .foregroundStyle(.tint)
             
             Spacer()
             
-            // 타이머
-            if showTimer {
-                Text("\(timerCount)")
+            if viewModel.showTimer {
+                Text("\(viewModel.timerCount)")
                     .font(.largeTitle)
                     .bold()
                     .padding()
                     .transition(.opacity)
             }
             
-            // 호흡 단계 텍스트
-            if showText {
-                Text(phaseText)
+            if viewModel.showText {
+                Text(viewModel.phaseText)
                     .font(.title)
                     .padding(.bottom, 159)
                     .transition(.opacity)
             }
         }
-        .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                Button(action: {
-                    router.backToMain() // MainView로 돌아가며 상태 초기화
-                }) {
+                Button(action: { router.backToMain() }) {
                     Image(systemName: "xmark")
                         .foregroundColor(.blue)
                 }
             }
-            ToolbarItem(placement: .navigationBarTrailing) {
-                HStack(spacing: 8) {
-                    ForEach(0..<3, id: \.self) { index in
-                        Circle()
-                            .fill(index < activeCircle ? Color.black : Color.gray)
-                            .frame(width: 10, height: 10)
-                    }
-                }
-            }
         }
         .onAppear {
-            startBreathingIntro()
+            viewModel.startBreathingIntro()
         }
     }
-    
-    // 호흡 준비 시작 - 첫 번째와 두 번째 멘트
-    private func startBreathingIntro() {
-        // 첫 번째 텍스트 단계 - 마음청소
-        phaseText = "마음청소를 시작할게요"
-        showText = true
-        withAnimation {
-            showText = true
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            withAnimation {
-                showText = false
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                // 두 번째 텍스트 단계 - 호흡에 집중
-                phaseText = "호흡에 집중하세요"
-                withAnimation {
-                    showText = true
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                    withAnimation {
-                        showText = false
-                    }
-                    startBreathingCycle()
-                }
-            }
-        }
-    }
-    
-    // 전체 호흡 반복 사이클 시작
-    private func startBreathingCycle() {
-        activeCircle = 0 // 초기화
-        repeatCycle(times: 3) {
-            finishBreathing()
-        }
-    }
-    
-    // 반복 사이클
-    private func repeatCycle(times: Int, completion: @escaping () -> Void) {
-        guard times > 0 else {
-            completion()
-            return
-        }
-        
-        activeCircle += 1 // 동그라미 활성화 업데이트
-        startBreathingPhase {
-            repeatCycle(times: times - 1, completion: completion)
-        }
-    }
-
-    // 호흡 단계 시작 (inhale, hold, exhale)
-    private func startBreathingPhase(completion: @escaping () -> Void) {
-        showTimer = true
-        
-        startPhase(phase: .inhale, duration: 5, text: "숨을 들이 쉬세요") {
-            self.startPhase(phase: .hold, duration: 5, text: "잠시 멈추세요") {
-                self.startPhase(phase: .exhale, duration: 5, text: "숨을 내쉬세요") {
-                    self.startPhase(phase: .hold, duration: 5, text: "잠시 멈추세요") {
-                        completion()
-                    }
-                }
-            }
-        }
-    }
-
-    // 특정 호흡 단계 진행
-    private func startPhase(phase: BreathingPhase, duration: Int, text: String, completion: @escaping () -> Void) {
-        currentPhase = phase
-        phaseText = text
-        timerCount = duration
-        showText = true
-
-        // 타이머 시작
-        Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
-            self.timerCount -= 1
-            if self.timerCount <= 0 {
-                timer.invalidate()
-                completion()
-            }
-        }
-    }
-    
-    // 호흡이 끝났을 때 Outro로 전환
-    private func finishBreathing() {
-        withAnimation {
-            router.push(view: .breathingOutroView) // Outro로 라우팅
-        }
-    }
-}
-
-#Preview {
-    BreathingMainView()
 }

--- a/Spha/Spha/Views/Breathing/BreathingMainView.swift
+++ b/Spha/Spha/Views/Breathing/BreathingMainView.swift
@@ -7,9 +7,13 @@
 //
 import SwiftUI
 
-struct BreathingMainView: View {
+struct BreathingMainView<BreathViewModel>: View where BreathViewModel: BreathingManager {
     @EnvironmentObject var router: RouterManager
-    @StateObject private var viewModel = BreathingMainViewModel()
+    @ObservedObject private var viewModel: BreathViewModel
+    
+    init(breathManager: BreathViewModel) {
+        self.viewModel = breathManager
+    }
     
     var body: some View {
         VStack {

--- a/Spha/Spha/Views/Breathing/BreathingMainViewModel.swift
+++ b/Spha/Spha/Views/Breathing/BreathingMainViewModel.swift
@@ -82,3 +82,4 @@ class BreathingMainViewModel: BreathingManager {
         }
     }
 }
+

--- a/Spha/Spha/Views/Breathing/BreathingMainViewModel.swift
+++ b/Spha/Spha/Views/Breathing/BreathingMainViewModel.swift
@@ -1,0 +1,84 @@
+//
+//  BreathingMainViewModel.swift
+//  Spha
+//
+//  Created by 추서연 on 11/21/24.
+//
+
+import Foundation
+import SwiftUI
+
+// iOS ViewModel
+class BreathingMainViewModel: BreathingManager {
+    @Published var phaseText: String = "마음청소를 시작할게요"
+    @Published var showText: Bool = true
+    @Published var timerCount: Int = 0
+    @Published var showTimer: Bool = false
+    @Published var activeCircle: Int = 0
+
+    private var currentTimer: Timer? // 타이머 상태 관리
+    
+    // 초기 인트로 시작
+    func startBreathingIntro() {
+        phaseText = "마음청소를 시작할게요"
+        showText = true
+        withAnimation { showText = true }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            withAnimation { self.showText = false }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                self.phaseText = "호흡에 집중하세요"
+                withAnimation { self.showText = true }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                    withAnimation { self.showText = false }
+                    self.startBreathingCycle()
+                }
+            }
+        }
+    }
+
+    // 호흡 사이클 시작
+    func startBreathingCycle() {
+        activeCircle = 0
+        repeatCycle(times: 3) { /* 모든 사이클 종료 */ }
+    }
+    
+    private func repeatCycle(times: Int, completion: @escaping () -> Void) {
+        guard times > 0 else {
+            completion()
+            return
+        }
+        activeCircle += 1
+        startBreathingPhase {
+            self.repeatCycle(times: times - 1, completion: completion)
+        }
+    }
+
+    func startBreathingPhase(completion: @escaping () -> Void) {
+        showTimer = true
+        startPhase(phase: .inhale, duration: 5, text: "숨을 들이 쉬세요") {
+            self.startPhase(phase: .hold, duration: 5, text: "잠시 멈추세요") {
+                self.startPhase(phase: .exhale, duration: 5, text: "숨을 내쉬세요") {
+                    self.startPhase(phase: .hold, duration: 5, text: "잠시 멈추세요") {
+                        completion()
+                    }
+                }
+            }
+        }
+    }
+
+    func startPhase(phase: BreathingPhase, duration: Int, text: String, completion: @escaping () -> Void) {
+        phaseText = text
+        timerCount = duration
+        showText = true
+
+        currentTimer?.invalidate()
+        currentTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
+            self.timerCount -= 1
+            if self.timerCount <= 0 {
+                timer.invalidate()
+                completion()
+            }
+        }
+    }
+}

--- a/Spha/Spha/Views/Home/MainViewModel.swift
+++ b/Spha/Spha/Views/Home/MainViewModel.swift
@@ -49,9 +49,9 @@ class MainViewModel: ObservableObject {
                 
                 for sample in samples {
                     let sdnnValue = sample.quantity.doubleValue(for: HKUnit.secondUnit(with: .milli))
-                    if sdnnValue > stressSdnnValue {
-                        stressCount += 1
-                    }
+//                    if sdnnValue > stressSdnnValue {
+//                        stressCount += 1
+//                    }
                 }
                 
                 self.recommendedCleaningCount = stressCount

--- a/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingMainView.swift
+++ b/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingMainView.swift
@@ -10,183 +10,34 @@ import SwiftUI
 
 struct WatchBreathingMainView: View {
     @EnvironmentObject var router: WatchRouterManager
-    
-    // 상태 변수들
-    @State private var showBreathingIntro = true // 인트로를 보여줄지 여부
-    @State private var breathingIntroOpacity: Double = 0.0 // 인트로 페이드 인 효과
-    @State private var phaseText: String = "마음청소를 시작할게요" // 단계별 텍스트
-    @State private var showText: Bool = true // 텍스트 표시 여부
-    @State private var timerCount: Int = 0 // 타이머 값
-    @State private var showTimer: Bool = false // 타이머 표시 여부
-    @State private var activeCircle: Int = 0 // 현재 활성화된 동그라미 (0~3)
-    @State private var currentTimer: Timer? // 타이머 상태 관리
+    @StateObject private var viewModel = WatchBreathingMainViewModel()
     
     var body: some View {
         VStack {
-            
             TabView {
                 VStack {
-                    // 인트로 화면 (페이드인 효과 없이)
-                    if showBreathingIntro {
-                        VStack {
-                            Image(systemName: "globe")
-                                .imageScale(.large)
-                                .foregroundStyle(.tint)
-                            Text("BreathingIntroView")
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .background(Color.blue)
-                        .opacity(breathingIntroOpacity) // 페이드인 효과
-                        .onAppear {
-                            // 애니메이션 없이 바로 나타나게 설정
-                            breathingIntroOpacity = 1.0
-                            
-                            // 일정 시간 후 메인 화면으로 이동
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                                showBreathingIntro = false
-                                startBreathingIntro() // 호흡 시작
-                            }
-                        }
-                    } else {
-                        // 호흡 메인 화면
-                        VStack {
-                            
-                            
-                            HStack(spacing: 8) {
-                                ForEach(0..<3, id: \.self) { index in
-                                    Circle()
-                                        .fill(index < activeCircle ? Color.gray : Color.white)
-                                        .frame(width: 10, height: 10)
-                                }
-                            }
-                            Image(systemName: "globe")
-                                .imageScale(.large)
-                                .foregroundStyle(.tint)
-                            
-                            
-                            // 호흡 단계 텍스트
-                            if showText {
-                                Text(phaseText)
-                                    .font(.caption2)
-                                    .transition(.opacity)
-                            }
-                        }
-                        .navigationBarBackButtonHidden(true)
-                        .onAppear {
-                            startBreathingIntro() // 호흡 시작
+                    HStack(spacing: 8) {
+                        ForEach(0..<3, id: \.self) { index in
+                            Circle()
+                                .fill(index < viewModel.activeCircle ? Color.gray : Color.white)
+                                .frame(width: 10, height: 10)
                         }
                     }
+                    Image(systemName: "globe")
+                        .imageScale(.large)
+                        .foregroundStyle(.tint)
                     
-                }
-                .tabItem {
-                    Text("Breathing Main")
-                }
-                
-                WatchBreathingExitView()
-                    .tabItem {
-                        Text("Exit")
-                    }
-            }
-            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .always))  // PageTabViewStyle을 사용하여 스와이프 가능하게 설정
-            .navigationBarBackButtonHidden(true)
-            
-            
-        }
-        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .always))  // PageTabViewStyle을 사용하여 스와이프 가능하게 설정
-        .navigationBarBackButtonHidden(true)
-    }
-    
-    // 호흡 준비 시작 - 첫 번째와 두 번째 멘트
-    private func startBreathingIntro() {
-        // 첫 번째 텍스트 단계 - 마음청소
-        phaseText = "마음청소를 시작할게요"
-        showText = true
-        withAnimation {
-            showText = true
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            withAnimation {
-                showText = false
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                // 두 번째 텍스트 단계 - 호흡에 집중
-                phaseText = "호흡에 집중하세요"
-                withAnimation {
-                    showText = true
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                    withAnimation {
-                        showText = false
-                    }
-                    startBreathingCycle() // 호흡 사이클 시작
-                }
-            }
-        }
-    }
-    
-    // 전체 호흡 반복 사이클 시작
-    private func startBreathingCycle() {
-        activeCircle = 0 // 초기화
-        repeatCycle(times: 3) {
-            finishBreathing() // 호흡 종료 처리
-        }
-    }
-    
-    private func finishBreathing() {
-        withAnimation {
-            router.push(view: .watchbreathingOutroView) // Outro로 라우팅
-        }
-    }
-    
-    // 반복 사이클
-    private func repeatCycle(times: Int, completion: @escaping () -> Void) {
-        guard times > 0 else {
-            completion()
-            return
-        }
-        
-        activeCircle += 1 // 동그라미 활성화 업데이트
-        startBreathingPhase {
-            repeatCycle(times: times - 1, completion: completion)
-        }
-    }
-    
-    // 호흡 단계 시작 (inhale, hold, exhale)
-    private func startBreathingPhase(completion: @escaping () -> Void) {
-        showTimer = true
-        
-        startPhase(phase: .inhale, duration: 5, text: "숨을 들이 쉬세요") {
-            self.startPhase(phase: .hold, duration: 5, text: "잠시 멈추세요") {
-                self.startPhase(phase: .exhale, duration: 5, text: "숨을 내쉬세요") {
-                    self.startPhase(phase: .hold, duration: 5, text: "잠시 멈추세요") {
-                        completion()
+                    if viewModel.showText {
+                        Text(viewModel.phaseText)
+                            .font(.caption2)
+                            .transition(.opacity)
                     }
                 }
+                .onAppear {
+                    viewModel.startBreathingIntro()
+                }
             }
+            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .always))
         }
     }
-    
-    // 특정 호흡 단계 진행
-    private func startPhase(phase: BreathingPhase, duration: Int, text: String, completion: @escaping () -> Void) {
-        phaseText = text
-        timerCount = duration
-        showText = true
-        
-        // 이전 타이머가 있으면 정리
-        currentTimer?.invalidate()
-        
-        // 새로운 타이머 시작
-        currentTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
-            self.timerCount -= 1
-            if self.timerCount <= 0 {
-                timer.invalidate()
-                completion()
-            }
-        }
-    }
-}
-
-#Preview {
-    WatchBreathingMainView()
-        .environmentObject(WatchRouterManager())
 }

--- a/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingMainViewModel.swift
+++ b/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingMainViewModel.swift
@@ -1,0 +1,82 @@
+//
+//  WatchBreathingMainViewModel.swift
+//  SphaWatch Watch App
+//
+//  Created by 추서연 on 11/21/24.
+//
+
+import Foundation
+import SwiftUI
+
+// watchOS ViewModel
+class WatchBreathingMainViewModel: BreathingManager {
+    @Published var phaseText: String = "마음청소를 시작할게요"
+    @Published var showText: Bool = true
+    @Published var timerCount: Int = 0
+    @Published var showTimer: Bool = false
+    @Published var activeCircle: Int = 0
+
+    private var currentTimer: Timer?
+    
+    func startBreathingIntro() {
+        phaseText = "마음청소를 시작할게요"
+        showText = true
+        withAnimation { showText = true }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            withAnimation { self.showText = false }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                self.phaseText = "호흡에 집중하세요"
+                withAnimation { self.showText = true }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                    withAnimation { self.showText = false }
+                    self.startBreathingCycle()
+                }
+            }
+        }
+    }
+
+    func startBreathingCycle() {
+        activeCircle = 0
+        repeatCycle(times: 3) { /* 모든 사이클 종료 */ }
+    }
+    
+    private func repeatCycle(times: Int, completion: @escaping () -> Void) {
+        guard times > 0 else {
+            completion()
+            return
+        }
+        activeCircle += 1
+        startBreathingPhase {
+            self.repeatCycle(times: times - 1, completion: completion)
+        }
+    }
+
+    func startBreathingPhase(completion: @escaping () -> Void) {
+        showTimer = true
+        startPhase(phase: .inhale, duration: 5, text: "숨을 들이 쉬세요") {
+            self.startPhase(phase: .hold, duration: 5, text: "잠시 멈추세요") {
+                self.startPhase(phase: .exhale, duration: 5, text: "숨을 내쉬세요") {
+                    self.startPhase(phase: .hold, duration: 5, text: "잠시 멈추세요") {
+                        completion()
+                    }
+                }
+            }
+        }
+    }
+
+    func startPhase(phase: BreathingPhase, duration: Int, text: String, completion: @escaping () -> Void) {
+        phaseText = text
+        timerCount = duration
+        showText = true
+
+        currentTimer?.invalidate()
+        currentTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
+            self.timerCount -= 1
+            if self.timerCount <= 0 {
+                timer.invalidate()
+                completion()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🔥 작업한 내용

- **iOS/WatchOS 뷰 모델 분리 및 리팩토링**
  - `BreathingViewModel`을 분리하여 iOS와 WatchOS에서 공통으로 사용할 수 있는 구조로 개선
  - WatchOS에 특화된 로직은 `WatchBreathingViewModel`로 분리하여 플랫폼별 책임을 명확히 구분
  
- **BreathingManager 구현**
  - `BreathingManager`를 도입하여 호흡 세션과 관련된 모든 비즈니스 로직을 관리하도록 구조화
  - 호흡 세션의 상태를 추적하고, 각 세션의 타이머 및 상태 변화에 따른 처리를 `BreathingManager`에서 담당하게 구현
  - `BreathingManager`에서 세션 시작, 종료, 일시 정지 등의 로직을 처리하며, WatchOS와 iOS에서의 세션 관리를 통합

- **코드 재사용성 및 유지보수성 향상**
  - 공통 로직을 별도의 파일로 분리하여 iOS와 WatchOS에서 중복 코드를 제거
  - 플랫폼별 커스텀 뷰 로직은 각 ViewModel에서만 관리되도록 설계


## ⭐️ PR Point

- 플랫폼 간 중복 로직을 제거하고, 각 플랫폼별 특성에 맞는 구조로 리팩토링하여 유지보수성을 개선했습니다.
- `BreathingViewModel`을 분리하면서 공통 기능과 플랫폼별 기능을 명확히 구분하였으며, 데이터 흐름을 간소화했습니다.

## 🔧 TODO

- WatchOS에서 햅틱 피드백 추가: WKInterfaceDevice의 `play()` 메서드를 활용하여 사용자 경험 개선.
- 추가 테스트: iOS 및 WatchOS에서의 뷰 모델 동작 테스트를 통해 안정성을 검증.
- UI 통합: iOS 및 WatchOS 뷰 레이아웃 최적화 작업.


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #29 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
