### PR TITLE
[Feat] IOS 호흡 세션 MindfulSession 연동 저장

### DIFF
--- a/Spha/Spha.xcodeproj/project.pbxproj
+++ b/Spha/Spha.xcodeproj/project.pbxproj
@@ -23,14 +23,6 @@
 		339C2D2C2CEB961200F1EE00 /* MindfulSessionTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339C2D2B2CEB961200F1EE00 /* MindfulSessionTestView.swift */; };
 		33ADDFF02CEDC68400513149 /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33ADDFEF2CEDC68400513149 /* Color+.swift */; };
 		33ADDFF22CEDC6AE00513149 /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33ADDFF12CEDC6AE00513149 /* Font+.swift */; };
-
-
-		33BA0AF12CEF700C00F3B570 /* MainInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA0AF02CEF700C00F3B570 /* MainInfoView.swift */; };
-		460BCEDC2CEE706A0018927C /* BreathingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEDB2CEE706A0018927C /* BreathingManager.swift */; };
-		460BCEDD2CEE70830018927C /* BreathingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEDB2CEE706A0018927C /* BreathingManager.swift */; };
-		460BCEDF2CEE708D0018927C /* BreathingMainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEDE2CEE708D0018927C /* BreathingMainViewModel.swift */; };
-		460BCEE12CEE70B00018927C /* WatchBreathingMainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEE02CEE70B00018927C /* WatchBreathingMainViewModel.swift */; };
-
 		33BA0ACC2CEE1F2300F3B570 /* OnboardingContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA0ACB2CEE1F2300F3B570 /* OnboardingContainerView.swift */; };
 		33BA0AD42CEE284400F3B570 /* HealthKitHRVAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA0AD32CEE284400F3B570 /* HealthKitHRVAuth.swift */; };
 		33BA0AD62CEF1E4E00F3B570 /* OnboardingStartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA0AD52CEF1E4E00F3B570 /* OnboardingStartView.swift */; };
@@ -39,6 +31,7 @@
 		33BA0AE82CEF21FA00F3B570 /* WatchGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA0AE72CEF21FA00F3B570 /* WatchGuide.swift */; };
 		33BA0AEA2CEF23B600F3B570 /* NotificationAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA0AE92CEF23B600F3B570 /* NotificationAuth.swift */; };
 		33BA0AEC2CEF255300F3B570 /* MindfulSessionAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA0AEB2CEF255300F3B570 /* MindfulSessionAuth.swift */; };
+		33BA0AF12CEF700C00F3B570 /* MainInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA0AF02CEF700C00F3B570 /* MainInfoView.swift */; };
 		460BCEDC2CEE706A0018927C /* BreathingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEDB2CEE706A0018927C /* BreathingManager.swift */; };
 		460BCEDD2CEE70830018927C /* BreathingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEDB2CEE706A0018927C /* BreathingManager.swift */; };
 		460BCEDF2CEE708D0018927C /* BreathingMainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEDE2CEE708D0018927C /* BreathingMainViewModel.swift */; };
@@ -86,6 +79,7 @@
 		46AEF6242CF02E3A005AECFB /* hold2.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 46AEF6222CF02E3A005AECFB /* hold2.mp4 */; };
 		46AEF6262CF02F15005AECFB /* pause.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 46AEF6252CF02F15005AECFB /* pause.mp4 */; };
 		46AEF6272CF02F15005AECFB /* pause.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 46AEF6252CF02F15005AECFB /* pause.mp4 */; };
+		46AEF6292CF252C7005AECFB /* BreathingOutroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46AEF6282CF252C7005AECFB /* BreathingOutroViewModel.swift */; };
 		B5296C7A2CE2FEAC00FFE20F /* SphaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296C792CE2FEAC00FFE20F /* SphaApp.swift */; };
 		B5296C7C2CE2FEAC00FFE20F /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296C7B2CE2FEAC00FFE20F /* ContentView.swift */; };
 		B5296C7E2CE2FEAD00FFE20F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5296C7D2CE2FEAD00FFE20F /* Assets.xcassets */; };
@@ -153,11 +147,6 @@
 		33ADDFEE2CEDC67100513149 /* AppleSDGothicNeoSB.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = AppleSDGothicNeoSB.ttf; sourceTree = "<group>"; };
 		33ADDFEF2CEDC68400513149 /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
 		33ADDFF12CEDC6AE00513149 /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
-		33BA0AF02CEF700C00F3B570 /* MainInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainInfoView.swift; sourceTree = "<group>"; };
-		33BA0AF22CEF8CAD00F3B570 /* AppleSDGothicNeoR.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = AppleSDGothicNeoR.ttf; sourceTree = "<group>"; };
-		460BCEDB2CEE706A0018927C /* BreathingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingManager.swift; sourceTree = "<group>"; };
-		460BCEDE2CEE708D0018927C /* BreathingMainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingMainViewModel.swift; sourceTree = "<group>"; };
-		460BCEE02CEE70B00018927C /* WatchBreathingMainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchBreathingMainViewModel.swift; sourceTree = "<group>"; };
 		33BA0ACB2CEE1F2300F3B570 /* OnboardingContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingContainerView.swift; sourceTree = "<group>"; };
 		33BA0AD32CEE284400F3B570 /* HealthKitHRVAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitHRVAuth.swift; sourceTree = "<group>"; };
 		33BA0AD52CEF1E4E00F3B570 /* OnboardingStartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingStartView.swift; sourceTree = "<group>"; };
@@ -166,6 +155,8 @@
 		33BA0AE72CEF21FA00F3B570 /* WatchGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchGuide.swift; sourceTree = "<group>"; };
 		33BA0AE92CEF23B600F3B570 /* NotificationAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAuth.swift; sourceTree = "<group>"; };
 		33BA0AEB2CEF255300F3B570 /* MindfulSessionAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindfulSessionAuth.swift; sourceTree = "<group>"; };
+		33BA0AF02CEF700C00F3B570 /* MainInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainInfoView.swift; sourceTree = "<group>"; };
+		33BA0AF22CEF8CAD00F3B570 /* AppleSDGothicNeoR.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = AppleSDGothicNeoR.ttf; sourceTree = "<group>"; };
 		460BCEDB2CEE706A0018927C /* BreathingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingManager.swift; sourceTree = "<group>"; };
 		460BCEDE2CEE708D0018927C /* BreathingMainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingMainViewModel.swift; sourceTree = "<group>"; };
 		460BCEE02CEE70B00018927C /* WatchBreathingMainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchBreathingMainViewModel.swift; sourceTree = "<group>"; };
@@ -191,6 +182,7 @@
 		46AEF61F2CF02E2A005AECFB /* hold1.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = hold1.mp4; sourceTree = "<group>"; };
 		46AEF6222CF02E3A005AECFB /* hold2.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = hold2.mp4; sourceTree = "<group>"; };
 		46AEF6252CF02F15005AECFB /* pause.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = pause.mp4; sourceTree = "<group>"; };
+		46AEF6282CF252C7005AECFB /* BreathingOutroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingOutroViewModel.swift; sourceTree = "<group>"; };
 		B5296C762CE2FEAC00FFE20F /* Spha.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Spha.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5296C792CE2FEAC00FFE20F /* SphaApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SphaApp.swift; sourceTree = "<group>"; };
 		B5296C7B2CE2FEAC00FFE20F /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -345,6 +337,7 @@
 				4667B0712CE7EA9000F58DB3 /* BreathingMainView.swift */,
 				460BCEDE2CEE708D0018927C /* BreathingMainViewModel.swift */,
 				4667B0732CE7EA9C00F58DB3 /* BreathingOutroView.swift */,
+				46AEF6282CF252C7005AECFB /* BreathingOutroViewModel.swift */,
 			);
 			path = Breathing;
 			sourceTree = "<group>";
@@ -686,6 +679,7 @@
 				334D95CB2CEE0A69007600D7 /* FilePathHelper.swift in Sources */,
 				33BA0AF12CEF700C00F3B570 /* MainInfoView.swift in Sources */,
 				464B4EB02CE4905300218B35 /* MainView.swift in Sources */,
+				46AEF6292CF252C7005AECFB /* BreathingOutroViewModel.swift in Sources */,
 				B5296CB22CE34BDB00FFE20F /* TodayStress.swift in Sources */,
 				33ADDFF02CEDC68400513149 /* Color+.swift in Sources */,
 				339C2D2C2CEB961200F1EE00 /* MindfulSessionTestView.swift in Sources */,

--- a/Spha/Spha/Views/Breathing/BreathingOutroView.swift
+++ b/Spha/Spha/Views/Breathing/BreathingOutroView.swift
@@ -9,37 +9,30 @@ import SwiftUI
 
 struct BreathingOutroView: View {
     @EnvironmentObject var router: RouterManager
+    @StateObject private var viewModel = BreathingOutroViewModel()
 
-    @State private var opacity: Double = 1.0
-    
     var body: some View {
         ZStack {
             Color.black
                 .edgesIgnoringSafeArea(.all)
-            
+
             VStack {
                 MP4PlayerView(videoURLString: "clean")
                     .frame(width: 330, height: 330)
-                    .padding(.top,50)
-                
+                    .padding(.top, 50)
+
                 Text("마음이 깨끗해졌어요")
                     .customFont(.body_0)
                     .foregroundColor(Color.white)
                     .padding()
             }
-            .opacity(opacity)
+            .opacity(viewModel.opacity)
         }
         .onAppear {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                withAnimation(.easeOut(duration: 1.0)) {
-                    opacity = 0.0
-                }
-                
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                    router.backToMain()
-                    
-                }
+            viewModel.fadeOutAnimation {
+                router.backToMain()
             }
+            viewModel.recordTestMindfulSession()
         }
         .navigationBarBackButtonHidden(true)
     }

--- a/Spha/Spha/Views/Breathing/BreathingOutroViewModel.swift
+++ b/Spha/Spha/Views/Breathing/BreathingOutroViewModel.swift
@@ -14,12 +14,15 @@ class BreathingOutroViewModel: ObservableObject {
     private let mindfulSessionManager = MindfulSessionManager()
 
     func fadeOutAnimation(completion: @escaping () -> Void) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            guard let self = self else { return }
+
             withAnimation(.easeOut(duration: 1.0)) {
                 self.opacity = 0.0
             }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+                guard let _ = self else { return }
                 completion()
             }
         }
@@ -27,10 +30,11 @@ class BreathingOutroViewModel: ObservableObject {
 
     func recordTestMindfulSession() {
         let startDate = Date()
-        let endDate = Calendar.current.date(byAdding: .minute, value: 10, to: startDate)!
+        let endDate = Calendar.current.date(byAdding: .minute, value: 1, to: startDate)!
 
-        mindfulSessionManager.recordMindfulSession(startDate: startDate, endDate: endDate) { success, error in
+        mindfulSessionManager.recordMindfulSession(startDate: startDate, endDate: endDate) { [weak self] success, error in
             DispatchQueue.main.async {
+                guard let self = self else { return } // self가 해제되었는지 확인
                 if success {
                     self.statusMessage = "Test Mindful Session Recorded Successfully!"
                 } else if let error = error {
@@ -41,4 +45,5 @@ class BreathingOutroViewModel: ObservableObject {
             }
         }
     }
+
 }

--- a/Spha/Spha/Views/Breathing/BreathingOutroViewModel.swift
+++ b/Spha/Spha/Views/Breathing/BreathingOutroViewModel.swift
@@ -1,0 +1,44 @@
+//
+//  BreathingOutroViewModel.swift
+//  Spha
+//
+//  Created by 추서연 on 11/24/24.
+//
+
+import SwiftUI
+
+class BreathingOutroViewModel: ObservableObject {
+    @Published var opacity: Double = 1.0
+    @Published var statusMessage: String? = nil
+
+    private let mindfulSessionManager = MindfulSessionManager()
+
+    func fadeOutAnimation(completion: @escaping () -> Void) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            withAnimation(.easeOut(duration: 1.0)) {
+                self.opacity = 0.0
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                completion()
+            }
+        }
+    }
+
+    func recordTestMindfulSession() {
+        let startDate = Date()
+        let endDate = Calendar.current.date(byAdding: .minute, value: 10, to: startDate)!
+
+        mindfulSessionManager.recordMindfulSession(startDate: startDate, endDate: endDate) { success, error in
+            DispatchQueue.main.async {
+                if success {
+                    self.statusMessage = "Test Mindful Session Recorded Successfully!"
+                } else if let error = error {
+                    self.statusMessage = "Error Recording Session: \(error.localizedDescription)"
+                } else {
+                    self.statusMessage = "Failed to record session."
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🔥 작업한 내용

- **BreathingOutroView 구현**
  - `BreathingOutroView`를 추가하여 종료 화면의 애니메이션 및 데이터 기록을 담당하도록 구현
  - 뷰와 로직 분리를 위해 `BreathingOutroViewModel`으로 분리

- **MindfulSession 기록 로직 추가**
  - `MindfulSessionManager`를 활용하여 테스트 세션 데이터를 HealthKit에 기록하는 기능 구현
  - `recordTestMindfulSession` 메서드를 통해 세션 기록


## ⭐️ PR Point
- 뷰와 로직을 분리하여 `BreathingOutroViewModel`에서 애니메이션 및 데이터 기록 로직을 관리하도록 개선했습니다.

## 🔧 TODO
- **HealthKit 데이터 저장 기능 검증**
  - HealthKit 데이터를 저장하는 기능의 성공 여부를 watchOS에서도 테스트할 필요가 있습니다.
  - watchOS 데이터 저장을 위한 권한 요청

## 🚨 관련 이슈
- Resolved: #56 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
