### PR TITLE
[Feat] WatchOS 호흡 세션 MindfulSession 연동 저장

### DIFF
--- a/Spha/Spha.xcodeproj/project.pbxproj
+++ b/Spha/Spha.xcodeproj/project.pbxproj
@@ -23,14 +23,6 @@
 		339C2D2C2CEB961200F1EE00 /* MindfulSessionTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339C2D2B2CEB961200F1EE00 /* MindfulSessionTestView.swift */; };
 		33ADDFF02CEDC68400513149 /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33ADDFEF2CEDC68400513149 /* Color+.swift */; };
 		33ADDFF22CEDC6AE00513149 /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33ADDFF12CEDC6AE00513149 /* Font+.swift */; };
-
-
-		33BA0AF12CEF700C00F3B570 /* MainInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA0AF02CEF700C00F3B570 /* MainInfoView.swift */; };
-		460BCEDC2CEE706A0018927C /* BreathingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEDB2CEE706A0018927C /* BreathingManager.swift */; };
-		460BCEDD2CEE70830018927C /* BreathingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEDB2CEE706A0018927C /* BreathingManager.swift */; };
-		460BCEDF2CEE708D0018927C /* BreathingMainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEDE2CEE708D0018927C /* BreathingMainViewModel.swift */; };
-		460BCEE12CEE70B00018927C /* WatchBreathingMainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEE02CEE70B00018927C /* WatchBreathingMainViewModel.swift */; };
-
 		33BA0ACC2CEE1F2300F3B570 /* OnboardingContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA0ACB2CEE1F2300F3B570 /* OnboardingContainerView.swift */; };
 		33BA0AD42CEE284400F3B570 /* HealthKitHRVAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA0AD32CEE284400F3B570 /* HealthKitHRVAuth.swift */; };
 		33BA0AD62CEF1E4E00F3B570 /* OnboardingStartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA0AD52CEF1E4E00F3B570 /* OnboardingStartView.swift */; };
@@ -39,6 +31,7 @@
 		33BA0AE82CEF21FA00F3B570 /* WatchGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA0AE72CEF21FA00F3B570 /* WatchGuide.swift */; };
 		33BA0AEA2CEF23B600F3B570 /* NotificationAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA0AE92CEF23B600F3B570 /* NotificationAuth.swift */; };
 		33BA0AEC2CEF255300F3B570 /* MindfulSessionAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA0AEB2CEF255300F3B570 /* MindfulSessionAuth.swift */; };
+		33BA0AF12CEF700C00F3B570 /* MainInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA0AF02CEF700C00F3B570 /* MainInfoView.swift */; };
 		460BCEDC2CEE706A0018927C /* BreathingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEDB2CEE706A0018927C /* BreathingManager.swift */; };
 		460BCEDD2CEE70830018927C /* BreathingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEDB2CEE706A0018927C /* BreathingManager.swift */; };
 		460BCEDF2CEE708D0018927C /* BreathingMainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BCEDE2CEE708D0018927C /* BreathingMainViewModel.swift */; };
@@ -153,11 +146,6 @@
 		33ADDFEE2CEDC67100513149 /* AppleSDGothicNeoSB.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = AppleSDGothicNeoSB.ttf; sourceTree = "<group>"; };
 		33ADDFEF2CEDC68400513149 /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
 		33ADDFF12CEDC6AE00513149 /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
-		33BA0AF02CEF700C00F3B570 /* MainInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainInfoView.swift; sourceTree = "<group>"; };
-		33BA0AF22CEF8CAD00F3B570 /* AppleSDGothicNeoR.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = AppleSDGothicNeoR.ttf; sourceTree = "<group>"; };
-		460BCEDB2CEE706A0018927C /* BreathingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingManager.swift; sourceTree = "<group>"; };
-		460BCEDE2CEE708D0018927C /* BreathingMainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingMainViewModel.swift; sourceTree = "<group>"; };
-		460BCEE02CEE70B00018927C /* WatchBreathingMainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchBreathingMainViewModel.swift; sourceTree = "<group>"; };
 		33BA0ACB2CEE1F2300F3B570 /* OnboardingContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingContainerView.swift; sourceTree = "<group>"; };
 		33BA0AD32CEE284400F3B570 /* HealthKitHRVAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitHRVAuth.swift; sourceTree = "<group>"; };
 		33BA0AD52CEF1E4E00F3B570 /* OnboardingStartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingStartView.swift; sourceTree = "<group>"; };
@@ -166,6 +154,8 @@
 		33BA0AE72CEF21FA00F3B570 /* WatchGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchGuide.swift; sourceTree = "<group>"; };
 		33BA0AE92CEF23B600F3B570 /* NotificationAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAuth.swift; sourceTree = "<group>"; };
 		33BA0AEB2CEF255300F3B570 /* MindfulSessionAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindfulSessionAuth.swift; sourceTree = "<group>"; };
+		33BA0AF02CEF700C00F3B570 /* MainInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainInfoView.swift; sourceTree = "<group>"; };
+		33BA0AF22CEF8CAD00F3B570 /* AppleSDGothicNeoR.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = AppleSDGothicNeoR.ttf; sourceTree = "<group>"; };
 		460BCEDB2CEE706A0018927C /* BreathingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingManager.swift; sourceTree = "<group>"; };
 		460BCEDE2CEE708D0018927C /* BreathingMainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingMainViewModel.swift; sourceTree = "<group>"; };
 		460BCEE02CEE70B00018927C /* WatchBreathingMainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchBreathingMainViewModel.swift; sourceTree = "<group>"; };
@@ -191,6 +181,8 @@
 		46AEF61F2CF02E2A005AECFB /* hold1.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = hold1.mp4; sourceTree = "<group>"; };
 		46AEF6222CF02E3A005AECFB /* hold2.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = hold2.mp4; sourceTree = "<group>"; };
 		46AEF6252CF02F15005AECFB /* pause.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = pause.mp4; sourceTree = "<group>"; };
+		46AEF62C2CF2757A005AECFB /* SphaWatch-Watch-App-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "SphaWatch-Watch-App-Info.plist"; sourceTree = SOURCE_ROOT; };
+		46AEF62D2CF27608005AECFB /* SphaWatch Watch App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "SphaWatch Watch App.entitlements"; sourceTree = "<group>"; };
 		B5296C762CE2FEAC00FFE20F /* Spha.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Spha.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5296C792CE2FEAC00FFE20F /* SphaApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SphaApp.swift; sourceTree = "<group>"; };
 		B5296C7B2CE2FEAC00FFE20F /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -417,6 +409,8 @@
 		B5296C8C2CE2FEC300FFE20F /* SphaWatch Watch App */ = {
 			isa = PBXGroup;
 			children = (
+				46AEF62D2CF27608005AECFB /* SphaWatch Watch App.entitlements */,
+				46AEF62C2CF2757A005AECFB /* SphaWatch-Watch-App-Info.plist */,
 				B5296CD42CE48F0900FFE20F /* Notification */,
 				B5296C8D2CE2FEC300FFE20F /* SphaWatchApp.swift */,
 				B5296CB92CE3623300FFE20F /* Manager */,
@@ -887,7 +881,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Spha/Preview Content\"";
-				DEVELOPMENT_TEAM = 6FFZZTFJHB;
+				DEVELOPMENT_TEAM = 5GCYZU3KDQ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Spha/Info.plist;
@@ -927,7 +921,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Spha/Preview Content\"";
-				DEVELOPMENT_TEAM = 6FFZZTFJHB;
+				DEVELOPMENT_TEAM = 5GCYZU3KDQ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Spha/Info.plist;
@@ -962,13 +956,19 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "SphaWatch Watch App/SphaWatch Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SphaWatch Watch App/Preview Content\"";
 				DEVELOPMENT_TEAM = 5GCYZU3KDQ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "SphaWatch-Watch-App-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = SphaWatch;
+				INFOPLIST_KEY_LSApplicationCategoryType = "";
+				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "\"앱에서 심박수 변동성(HRV)을 기록하고 분석하기 위해 HealthKit 데이터를 사용합니다.\"";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "\"앱에서 심박수 변동성(HRV)을 기록하고 분석하기 위해 HealthKit 데이터를 사용합니다.\"";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "\"앱에서 심박수 변동성(HRV)을 기록하고 분석하기 위해 HealthKit 데이터를 사용합니다.\"";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.sophia.Spha;
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
@@ -993,13 +993,19 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "SphaWatch Watch App/SphaWatch Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SphaWatch Watch App/Preview Content\"";
 				DEVELOPMENT_TEAM = 5GCYZU3KDQ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "SphaWatch-Watch-App-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = SphaWatch;
+				INFOPLIST_KEY_LSApplicationCategoryType = "";
+				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "\"앱에서 심박수 변동성(HRV)을 기록하고 분석하기 위해 HealthKit 데이터를 사용합니다.\"";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "\"앱에서 심박수 변동성(HRV)을 기록하고 분석하기 위해 HealthKit 데이터를 사용합니다.\"";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "\"앱에서 심박수 변동성(HRV)을 기록하고 분석하기 위해 HealthKit 데이터를 사용합니다.\"";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.sophia.Spha;
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;

--- a/Spha/SphaWatch Watch App/SphaWatch Watch App.entitlements
+++ b/Spha/SphaWatch Watch App/SphaWatch Watch App.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+	<key>com.apple.developer.healthkit.access</key>
+	<array/>
+	<key>com.apple.developer.healthkit.background-delivery</key>
+	<true/>
+</dict>
+</plist>

--- a/Spha/SphaWatch Watch App/SphaWatchApp.swift
+++ b/Spha/SphaWatch Watch App/SphaWatchApp.swift
@@ -11,6 +11,13 @@ import SwiftUI
 @main
 struct SphaWatch_Watch_AppApp: App {
     @StateObject var router: WatchRouterManager = WatchRouterManager()
+    private let mindfulSessionManager = MindfulSessionManager()
+    
+    init() {
+            // 앱 시작시 권한 요청
+            requestAuthorization()
+        }
+    
     var body: some Scene {
         WindowGroup {
             NavigationStack(path: $router.path) {
@@ -23,5 +30,8 @@ struct SphaWatch_Watch_AppApp: App {
             }
             .environmentObject(router)
         }
+    }
+    private func requestAuthorization() {
+        mindfulSessionManager.requestAuthorization()
     }
 }

--- a/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingOutroView.swift
+++ b/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingOutroView.swift
@@ -23,7 +23,7 @@ struct WatchBreathingOutroView: View {
         }
         .opacity(opacity)
         .onAppear {
-            //TODO: 오늘의 Mindful 세션 조회 후 개수 +1
+            viewModel.recordTestMindfulSession()
             
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                 withAnimation(.easeOut(duration: 1.0)) {

--- a/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingOutroView.swift
+++ b/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingOutroView.swift
@@ -19,9 +19,9 @@ struct WatchBreathingOutroView: View {
                 .font(.caption)
                 .padding()
         }
-        .opacity(viewModel.opacity)  // Bind opacity from ViewModel
+        .opacity(viewModel.opacity)
         .onAppear {
-            viewModel.startFadeOutProcess(router: router)  // Trigger ViewModel action on appear
+            viewModel.startFadeOutProcess(router: router)
         }
         .navigationBarBackButtonHidden(true)
     }

--- a/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingOutroView.swift
+++ b/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingOutroView.swift
@@ -11,8 +11,6 @@ struct WatchBreathingOutroView: View {
     @EnvironmentObject var router: WatchRouterManager
     @StateObject private var viewModel = WatchBreathingOutroViewModel() // ViewModel을 StateObject로 사용
     
-    @State private var opacity: Double = 1.0
-    
     var body: some View {
         VStack {
             WatchBreathingMP4PlayerView(videoName: "clean")
@@ -21,20 +19,9 @@ struct WatchBreathingOutroView: View {
                 .font(.caption)
                 .padding()
         }
-        .opacity(opacity)
+        .opacity(viewModel.opacity)  // Bind opacity from ViewModel
         .onAppear {
-            viewModel.recordTestMindfulSession()
-            
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                withAnimation(.easeOut(duration: 1.0)) {
-                    opacity = 0.0  // Fade out
-                }
-                
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                    router.backToWatchMain()
-                    router.pop()
-                }
-            }
+            viewModel.startFadeOutProcess(router: router)  // Trigger ViewModel action on appear
         }
         .navigationBarBackButtonHidden(true)
     }

--- a/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingOutroViewModel.swift
+++ b/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingOutroViewModel.swift
@@ -45,8 +45,8 @@ class WatchBreathingOutroViewModel: ObservableObject {
                 strongSelf.opacity = 0.0  // Fade out
             }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                guard let strongSelf = self else { return }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+                guard self != nil else { return }
                 router.backToWatchMain()
                 router.pop()
             }

--- a/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingOutroViewModel.swift
+++ b/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingOutroViewModel.swift
@@ -18,10 +18,11 @@ class WatchBreathingOutroViewModel: ObservableObject {
     //MindfulSession 세션 저장
     func recordTestMindfulSession() {
         let startDate = Date()
-        let endDate = Calendar.current.date(byAdding: .minute, value: 10, to: startDate)!
+        let endDate = Calendar.current.date(byAdding: .minute, value: 1, to: startDate)!
 
-        mindfulSessionManager.recordMindfulSession(startDate: startDate, endDate: endDate) { success, error in
+        mindfulSessionManager.recordMindfulSession(startDate: startDate, endDate: endDate) { [weak self] success, error in
             DispatchQueue.main.async {
+                guard let self = self else { return }
                 if success {
                     self.statusMessage = "Test Mindful Session Recorded Successfully!"
                 } else if let error = error {
@@ -32,6 +33,7 @@ class WatchBreathingOutroViewModel: ObservableObject {
             }
         }
     }
+
 
     func startFadeOutProcess(router: WatchRouterManager) {
         recordTestMindfulSession()

--- a/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingOutroViewModel.swift
+++ b/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingOutroViewModel.swift
@@ -9,6 +9,23 @@ import Foundation
 import Combine
 
 class WatchBreathingOutroViewModel: ObservableObject {
+    @Published var statusMessage: String? = nil
+    private let mindfulSessionManager = MindfulSessionManager()
 
-    // TODO: - 오늘의 Mindful Session 조회 후 세션 개수 +1
+    func recordTestMindfulSession() {
+            let startDate = Date()
+            let endDate = Calendar.current.date(byAdding: .minute, value: 10, to: startDate)!
+
+            mindfulSessionManager.recordMindfulSession(startDate: startDate, endDate: endDate) { success, error in
+                DispatchQueue.main.async {
+                    if success {
+                        self.statusMessage = "Test Mindful Session Recorded Successfully!"
+                    } else if let error = error {
+                        self.statusMessage = "Error Recording Session: \(error.localizedDescription)"
+                    } else {
+                        self.statusMessage = "Failed to record session."
+                    }
+                }
+            }
+        }
 }

--- a/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingOutroViewModel.swift
+++ b/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingOutroViewModel.swift
@@ -37,16 +37,21 @@ class WatchBreathingOutroViewModel: ObservableObject {
 
     func startFadeOutProcess(router: WatchRouterManager) {
         recordTestMindfulSession()
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+            guard let strongSelf = self else { return }
+
             withAnimation(.easeOut(duration: 1.0)) {
-                self.opacity = 0.0  // Fade out
+                strongSelf.opacity = 0.0  // Fade out
             }
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                guard let strongSelf = self else { return }
                 router.backToWatchMain()
                 router.pop()
             }
         }
     }
+
+
 }

--- a/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingOutroViewModel.swift
+++ b/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingOutroViewModel.swift
@@ -7,25 +7,44 @@
 
 import Foundation
 import Combine
+import SwiftUI
 
 class WatchBreathingOutroViewModel: ObservableObject {
     @Published var statusMessage: String? = nil
+    @Published var opacity: Double = 1.0
+    
     private let mindfulSessionManager = MindfulSessionManager()
 
+    //MindfulSession 세션 저장
     func recordTestMindfulSession() {
-            let startDate = Date()
-            let endDate = Calendar.current.date(byAdding: .minute, value: 10, to: startDate)!
+        let startDate = Date()
+        let endDate = Calendar.current.date(byAdding: .minute, value: 10, to: startDate)!
 
-            mindfulSessionManager.recordMindfulSession(startDate: startDate, endDate: endDate) { success, error in
-                DispatchQueue.main.async {
-                    if success {
-                        self.statusMessage = "Test Mindful Session Recorded Successfully!"
-                    } else if let error = error {
-                        self.statusMessage = "Error Recording Session: \(error.localizedDescription)"
-                    } else {
-                        self.statusMessage = "Failed to record session."
-                    }
+        mindfulSessionManager.recordMindfulSession(startDate: startDate, endDate: endDate) { success, error in
+            DispatchQueue.main.async {
+                if success {
+                    self.statusMessage = "Test Mindful Session Recorded Successfully!"
+                } else if let error = error {
+                    self.statusMessage = "Error Recording Session: \(error.localizedDescription)"
+                } else {
+                    self.statusMessage = "Failed to record session."
                 }
             }
         }
+    }
+
+    func startFadeOutProcess(router: WatchRouterManager) {
+        recordTestMindfulSession()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            withAnimation(.easeOut(duration: 1.0)) {
+                self.opacity = 0.0  // Fade out
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                router.backToWatchMain()
+                router.pop()
+            }
+        }
+    }
 }

--- a/Spha/SphaWatch Watch App/Views/Home/WatchMainStatusView.swift
+++ b/Spha/SphaWatch Watch App/Views/Home/WatchMainStatusView.swift
@@ -60,5 +60,9 @@ struct WatchMainStatusView: View {
             }
         
         }
+        .onAppear {
+                    // Fetch mindful sessions 호흡 실행 횟수
+                    viewModel.fetchTodaySessions()
+                }
     }
 }

--- a/Spha/SphaWatch Watch App/Views/Home/WatchMainStatusViewModel.swift
+++ b/Spha/SphaWatch Watch App/Views/Home/WatchMainStatusViewModel.swift
@@ -64,7 +64,7 @@ class WatchMainStatusViewModel: ObservableObject {
     }
     
     // DailyMindfulSession 요청
-    private func fetchTodaySessions() {
+    func fetchTodaySessions() {
         MindfulService.fetchMindfulSessions(for: Date()) { sessions, error in
                 if let error = error {
                     print("Error fetching today's sessions: \(error.localizedDescription)")

--- a/Spha/SphaWatch-Watch-App-Info.plist
+++ b/Spha/SphaWatch-Watch-App-Info.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>


### PR DESCRIPTION
## 🔥 작업한 내용
- **WatchOS HealthKit 기본 세팅**

- **WatchBreathingOutroView 구현**
  - `WatchBreathingOutroView`를 추가하여 종료 화면의 애니메이션 및 데이터 기록을 담당하도록 구현
  - 뷰와 로직 분리를 위해 `WatchBreathingOutroViewModel`으로 분리

- **MindfulSession 기록 로직 추가**
  - `MindfulSessionManager`를 활용하여 테스트 세션 데이터를 HealthKit에 기록하는 기능 구현
  - `recordTestMindfulSession` 메서드를 통해 세션 기록

## ⭐️ PR Point
- 뷰와 로직을 분리하여 `WatchBreathingOutroViewModel`에서 애니메이션 및 데이터 기록 로직을 관리하도록 개선했습니다.

## 🔧 TODO
- WatchOS HRV 기록시 Notification 전송 후  BreathingSession 연결

## 🚨 관련 이슈
- Resolved: #54 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
