### PR TITLE
[Chore] WatchOS 호흡 세션 종료시 햅틱 중단 로직 추가

### DIFF
--- a/Spha/SphaWatch Watch App/Manager/HapticManager.swift
+++ b/Spha/SphaWatch Watch App/Manager/HapticManager.swift
@@ -11,6 +11,7 @@ import WatchKit
 
 class HapticManager {
     private var device: WKInterfaceDevice
+    private var isHapticStopped = false
 
     init() {
         device = WKInterfaceDevice.current()  // WatchOS에서 WKInterfaceDevice 사용
@@ -19,7 +20,9 @@ class HapticManager {
     func playInhaleHaptic() {
         Task {
             await startHapticRepeat(interval: 0.5, duration: 5) {
-                self.device.play(.stop)
+                if !self.isHapticStopped {
+                                    self.device.play(.stop)
+                                }
             }
         }
     }
@@ -27,7 +30,9 @@ class HapticManager {
     func playHoldHaptic() {
         Task {
             await startHapticRepeat(interval: 0.5, duration: 5) {
-                self.device.play(.start)
+                if !self.isHapticStopped {
+                                    self.device.play(.start)
+                                }
             }
         }
     }
@@ -35,12 +40,15 @@ class HapticManager {
     func playExhaleHaptic() {
         Task {
             await startHapticRepeat(interval: 0.5, duration: 5) {
-                self.device.play(.success)
+                if !self.isHapticStopped {
+                                    self.device.play(.success)
+                                }
             }
         }
     }
 
     func stopHaptic() {
+        self.isHapticStopped = true
         device.play(.stop)
     }
 
@@ -48,7 +56,7 @@ class HapticManager {
         var elapsed: TimeInterval = 0
         
         while elapsed < duration {
-            await Task.sleep(UInt64(interval * 1_000_000_000)) 
+            await Task.sleep(UInt64(interval * 1_000_000_000))
             elapsed += interval
             hapticAction()
         }

--- a/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingExitView.swift
+++ b/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingExitView.swift
@@ -10,9 +10,12 @@ import SwiftUI
 struct WatchBreathingExitView: View {
     @EnvironmentObject var router: WatchRouterManager
     
+    var viewModel: WatchBreathingMainViewModel
+    
     var body: some View {
         VStack {
             Button(action: {
+                viewModel.stopBreathingCycle()
                 // 버튼 클릭 시 이전 WatchBreathingSelectionView로 이동
                 router.pop()
                  
@@ -29,6 +32,6 @@ struct WatchBreathingExitView: View {
 }
 
 #Preview {
-    WatchBreathingExitView()
+    WatchBreathingExitView(viewModel: WatchBreathingMainViewModel())
         .environmentObject(WatchRouterManager())
 }

--- a/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingMainView.swift
+++ b/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingMainView.swift
@@ -4,8 +4,6 @@
 //
 //  Created by 추서연 on 11/19/24.
 //
-
-
 import SwiftUI
 
 struct WatchBreathingMainView: View {
@@ -49,7 +47,8 @@ struct WatchBreathingMainView: View {
                 Text("Breathing Main")
             }
             
-            WatchBreathingExitView()
+            WatchBreathingExitView(viewModel: viewModel)
+                .environmentObject(viewModel)
                 .tabItem {
                     Text("Exit")
                 }

--- a/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingMainViewModel.swift
+++ b/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingMainViewModel.swift
@@ -35,6 +35,7 @@ class WatchBreathingMainViewModel: BreathingManager {
     func stopBreathingCycle() {
         hapticManager.stopHaptic() // 햅틱 피드백 멈추기
         currentTask?.cancel() // 현재 태스크 취소
+        currentTask=nil
         isBreathingCompleted = false
     }
     

--- a/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingMainViewModel.swift
+++ b/Spha/SphaWatch Watch App/Views/Breathing/WatchBreathingMainViewModel.swift
@@ -13,9 +13,10 @@ class WatchBreathingMainViewModel: BreathingManager {
     @Published var showTimer: Bool = false
     @Published var activeCircle: Int = 0
     @Published var isBreathingCompleted: Bool = false
-
+    
     private var hapticManager = HapticManager()
-
+    private var currentTask: Task<Void, Never>?
+    
     func startBreathingIntro() {
         Task {
             await startPhase(phase: .ready, duration: 2)
@@ -23,14 +24,20 @@ class WatchBreathingMainViewModel: BreathingManager {
             startBreathingCycle()
         }
     }
-
+    
     func startBreathingCycle() {
         activeCircle = 0
         repeatCycle(times: 3) {
             self.isBreathingCompleted = true
         }
     }
-
+    
+    func stopBreathingCycle() {
+        hapticManager.stopHaptic() // 햅틱 피드백 멈추기
+        currentTask?.cancel() // 현재 태스크 취소
+        isBreathingCompleted = false
+    }
+    
     private func repeatCycle(times: Int, completion: @escaping () -> Void) {
         guard times > 0 else {
             completion()
@@ -41,7 +48,7 @@ class WatchBreathingMainViewModel: BreathingManager {
             self.repeatCycle(times: times - 1, completion: completion)
         }
     }
-
+    
     func startBreathingPhase(completion: @escaping () -> Void) {
         showTimer = true
         
@@ -58,14 +65,14 @@ class WatchBreathingMainViewModel: BreathingManager {
             completion()
         }
     }
-
+    
     func videoName(for text: String) -> String {
         guard let phase = BreathingPhase(rawValue: text) else {
             return "start"
         }
         return phase.videoName
     }
-
+    
     func startPhase(phase: BreathingPhase, duration: Int) async {
         phaseText = phase.rawValue
         showText = true


### PR DESCRIPTION
## 🔥 작업한 내용
- `WatchBreathingExitView`에 `viewModel`을 파라미터로 전달하여, 종료 버튼 클릭 시 `stopBreathingCycle()` 메서드를 호출
- `WatchBreathingMainView`에서 `viewModel`을 `WatchBreathingExitView`로 전달하여, "종료" 버튼을 눌렀을 때 호흡 사이클과 햅틱이 중단

## ⭐️ PR Point
- `WatchBreathingExitView`에 `viewModel`을 전달하는 방식으로, 종료 시 `stopBreathingCycle()`이 정상적으로 작동하는지 확인해 주세요.
- `stopBreathingCycle()`이 모든 호흡 사이클을 중단하고, 햅틱을 멈추는지 테스트 부탁드립니다.
- 전체적인 화면 전환 및 버튼 클릭 시 예상대로 동작하는지 확인 부탁드립니다.

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
 <img src="https://github.com/user-attachments/assets/393c4027-f2d5-4b40-8a5e-ee678004111f" width="250"/>

## 🚨 관련 이슈
- Resolved: #57 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
