### PR TITLE
[Feat] NotificationManager 통합

### DIFF
--- a/Spha/Shared/Managers/NotificationManager.swift
+++ b/Spha/Shared/Managers/NotificationManager.swift
@@ -92,6 +92,7 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
     ) {
         switch response.actionIdentifier {
         case "OPEN_APP":
+            // TODO: WatchBreathingMainView로 이동하도록
             #if os(watchOS)
             WKApplication.shared().activate()
             #endif

--- a/Spha/Shared/Managers/NotificationManager.swift
+++ b/Spha/Shared/Managers/NotificationManager.swift
@@ -92,10 +92,9 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
     ) {
         switch response.actionIdentifier {
         case "OPEN_APP":
-            // TODO: WatchBreathingMainView로 이동하도록
-            #if os(watchOS)
-            WKApplication.shared().activate()
-            #endif
+        #if os(watchOS)
+        // TODO: WatchApp 진입
+        #endif
         case "CANCEL":
             print("알림 취소")
         default:

--- a/Spha/Shared/Managers/NotificationManager.swift
+++ b/Spha/Shared/Managers/NotificationManager.swift
@@ -23,6 +23,7 @@ class NotificationManager: NSObject, NotificationInterface {
         super.init()
         setupNotifications()
     }
+
     
     private func setupNotifications() {
         let openAppAction = UNNotificationAction(
@@ -91,13 +92,15 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
     ) {
         switch response.actionIdentifier {
         case "OPEN_APP":
-            print("앱 실행")
-            // TODO: 앱 실행 관련 추가 로직 구현
+            #if os(watchOS)
+            WKApplication.shared().activate()
+            #endif
         case "CANCEL":
             print("알림 취소")
         default:
             break
         }
+        
         
         completionHandler()
     }

--- a/Spha/Shared/Managers/NotificationManager.swift
+++ b/Spha/Shared/Managers/NotificationManager.swift
@@ -1,21 +1,25 @@
 //
 //  NotificationManager.swift
-//  SphaWatch Watch App
+//  Spha
 //
-//  Created by 지영 on 11/12/24.
+//  Created by 지영 on 11/25/24.
 //
 
-import WatchKit
+import Foundation
 import UserNotifications
+#if os(watchOS)
+import WatchKit
+#endif
 
 protocol NotificationInterface {
-    func handleStress()
+    func sendBreathingAlert()
 }
 
 class NotificationManager: NSObject, NotificationInterface {
+    static let shared = NotificationManager()
     private let notificationCenter = UNUserNotificationCenter.current()
     
-    override init() {
+    private override init() {
         super.init()
         setupNotifications()
     }
@@ -57,14 +61,16 @@ class NotificationManager: NSObject, NotificationInterface {
         notificationCenter.delegate = self
     }
     
-    func handleStress() {
+    func sendBreathingAlert() {
         let content = UNMutableNotificationContent()
         content.title = "Spha"
-        content.body = "마음이 더러워 졌어요\n청소하러 가요"
+        content.body = "마음에 먼지가 쌓였어요\n청소하러 가요"
         content.sound = .default
         content.categoryIdentifier = "HRV_ALERT"  // 카테고리 지정
         
+        #if os(watchOS)
         WKInterfaceDevice.current().play(.notification)
+        #endif
         
         let request = UNNotificationRequest(
             identifier: UUID().uuidString,
@@ -76,7 +82,7 @@ class NotificationManager: NSObject, NotificationInterface {
     }
 }
 
-// 알림 액션 처리를 위한 델리게이트 확장
+// MARK: - UNUserNotificationCenterDelegate
 extension NotificationManager: UNUserNotificationCenterDelegate {
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
@@ -105,3 +111,4 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
         completionHandler([.banner, .sound])
     }
 }
+

--- a/Spha/Spha.xcodeproj/project.pbxproj
+++ b/Spha/Spha.xcodeproj/project.pbxproj
@@ -93,13 +93,14 @@
 		B5296CAA2CE3005800FFE20F /* StressLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296CA92CE3005800FFE20F /* StressLevel.swift */; };
 		B5296CAE2CE3009900FFE20F /* HealthKitManager+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296CAD2CE3009900FFE20F /* HealthKitManager+iOS.swift */; };
 		B5296CB02CE34B1E00FFE20F /* BreathingPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296CAF2CE34B1E00FFE20F /* BreathingPhase.swift */; };
-		B5296CBB2CE3623F00FFE20F /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296CBA2CE3623F00FFE20F /* NotificationManager.swift */; };
 		B5296CD62CE48F6000FFE20F /* NotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296CD52CE48F6000FFE20F /* NotificationView.swift */; };
 		B5296D222CEBA4A100FFE20F /* DailyStatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296D202CEBA4A100FFE20F /* DailyStatisticsView.swift */; };
 		B5296D252CEBA4B300FFE20F /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296D232CEBA4B300FFE20F /* Date+.swift */; };
 		B5296D292CECB01400FFE20F /* MindDustLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296D282CECB01300FFE20F /* MindDustLevel.swift */; };
 		B5296D312CEED9BC00FFE20F /* DailyStatisticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296D302CEED9BC00FFE20F /* DailyStatisticsViewModel.swift */; };
 		B5296D332CEF241400FFE20F /* DailyStressRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296D322CEF241400FFE20F /* DailyStressRecord.swift */; };
+		B5296D3B2CF459E900FFE20F /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296D3A2CF459E900FFE20F /* NotificationManager.swift */; };
+		B5296D3C2CF459E900FFE20F /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5296D3A2CF459E900FFE20F /* NotificationManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -199,7 +200,6 @@
 		B5296CA92CE3005800FFE20F /* StressLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StressLevel.swift; sourceTree = "<group>"; };
 		B5296CAD2CE3009900FFE20F /* HealthKitManager+iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HealthKitManager+iOS.swift"; sourceTree = "<group>"; };
 		B5296CAF2CE34B1E00FFE20F /* BreathingPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingPhase.swift; sourceTree = "<group>"; };
-		B5296CBA2CE3623F00FFE20F /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		B5296CD52CE48F6000FFE20F /* NotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationView.swift; sourceTree = "<group>"; };
 		B5296CD92CE49C3200FFE20F /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
 		B5296D202CEBA4A100FFE20F /* DailyStatisticsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DailyStatisticsView.swift; sourceTree = "<group>"; };
@@ -207,6 +207,7 @@
 		B5296D282CECB01300FFE20F /* MindDustLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindDustLevel.swift; sourceTree = "<group>"; };
 		B5296D302CEED9BC00FFE20F /* DailyStatisticsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyStatisticsViewModel.swift; sourceTree = "<group>"; };
 		B5296D322CEF241400FFE20F /* DailyStressRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyStressRecord.swift; sourceTree = "<group>"; };
+		B5296D3A2CF459E900FFE20F /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -459,6 +460,7 @@
 				331A5B8B2CE48FF500E16AE2 /* HealthKitManager */,
 				464B4ED22CE4961B00218B35 /* RouterManager.swift */,
 				460BCEDB2CEE706A0018927C /* BreathingManager.swift */,
+				B5296D3A2CF459E900FFE20F /* NotificationManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -499,7 +501,6 @@
 		B5296CB92CE3623300FFE20F /* Manager */ = {
 			isa = PBXGroup;
 			children = (
-				B5296CBA2CE3623F00FFE20F /* NotificationManager.swift */,
 				4667B0812CECB14000F58DB3 /* WatchRouterManager.swift */,
 				46AEF60F2CEFCFDF005AECFB /* HapticManager.swift */,
 			);
@@ -678,6 +679,7 @@
 				33BA0AEC2CEF255300F3B570 /* MindfulSessionAuth.swift in Sources */,
 				B5296CAA2CE3005800FFE20F /* StressLevel.swift in Sources */,
 				33BA0AD42CEE284400F3B570 /* HealthKitHRVAuth.swift in Sources */,
+				B5296D3B2CF459E900FFE20F /* NotificationManager.swift in Sources */,
 				B5296D292CECB01400FFE20F /* MindDustLevel.swift in Sources */,
 				464B4ED32CE4961B00218B35 /* RouterManager.swift in Sources */,
 				B5296D332CEF241400FFE20F /* DailyStressRecord.swift in Sources */,
@@ -718,11 +720,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				468F809E2CEF2A3B008E7F48 /* WatchBreathingMP4PlayerView.swift in Sources */,
-				B5296CBB2CE3623F00FFE20F /* NotificationManager.swift in Sources */,
 				B5296C902CE2FEC300FFE20F /* ContentView.swift in Sources */,
 				46AEF6022CEF8855005AECFB /* Color+.swift in Sources */,
 				4667B08A2CECBA5900F58DB3 /* WatchBreathingMainView.swift in Sources */,
 				46AEF60B2CEF8C64005AECFB /* FilePathHelper.swift in Sources */,
+				B5296D3C2CF459E900FFE20F /* NotificationManager.swift in Sources */,
 				B5296C8E2CE2FEC300FFE20F /* SphaWatchApp.swift in Sources */,
 				B5296CD62CE48F6000FFE20F /* NotificationView.swift in Sources */,
 				460BCEE12CEE70B00018927C /* WatchBreathingMainViewModel.swift in Sources */,

--- a/Spha/SphaWatch Watch App/Notification/NotificationView.swift
+++ b/Spha/SphaWatch Watch App/Notification/NotificationView.swift
@@ -8,12 +8,12 @@
 import SwiftUI
 
 struct NotificationView: View {
-    let notiManager = NotificationManager()
+//    let notiManager = NotificationManager()
     
     var body: some View {
         VStack {
             Button("테스트 알림") {
-                notiManager.handleStress()
+                NotificationManager.shared.sendBreathingAlert()
             }
         }
     }


### PR DESCRIPTION
## 🔥 작업한 내용
- watch에서 가지고 있던 NotificationManager를 shared로 통합했습니다


## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- shared 싱글톤 인스턴스를 추가하여 앱 전체에서 하나의 NotificationManager를 공유할 수 있도록 했습니다
- 기존에 handleStress() 함수명이 직관적이지 않다고 생각해 sendBreathingAlert()로 수정했습니다


## 🦾 TODO
- 지금은 워치앱 실행까지만 구현이 되어있어 이후 추가적으로 WatchBreathingMainView로 이동하도록 해야합니다


## 🚨 관련 이슈
- Resolved: #70 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
