### PR TITLE
Fix: #106-IOS 호흡뷰 문구 수정 및 인디케이터 수정

### DIFF
--- a/Spha/Spha/Views/Breathing/BreathingMainView.swift
+++ b/Spha/Spha/Views/Breathing/BreathingMainView.swift
@@ -21,18 +21,18 @@ struct BreathingMainView<BreathViewModel>: View where BreathViewModel: Breathing
                 .allowsHitTesting(false) 
                 .frame(width: 300, height: 300)
                 .padding(.top, 164)
-            
-            Spacer()
-            
+
             if viewModel.showTimer {
                 Text("\(viewModel.timerCount)")
                     .font(.title)
                     .foregroundColor(.white)
-                    .padding(.bottom, 10)
+                    .padding(.top, 10)
                     .transition(.opacity)
             }
             
-            if viewModel.showText {
+            Spacer()
+            
+            if viewModel.showText && viewModel.activeCircle < 2 {
                 Text(viewModel.phaseText)
                     .customFont(.body_0)
                     .foregroundColor(.gray0)
@@ -52,7 +52,7 @@ struct BreathingMainView<BreathViewModel>: View where BreathViewModel: Breathing
                 HStack(spacing: 8) {
                     ForEach(0..<3, id: \.self) { index in
                         Circle()
-                            .fill(index < viewModel.activeCircle ? Color.gray : Color.white)
+                            .fill(index < viewModel.activeCircle ? Color.white : Color.gray)
                             .frame(width: 10, height: 10)
                     }
                 }

--- a/Spha/Spha/Views/Breathing/BreathingMainViewModel.swift
+++ b/Spha/Spha/Views/Breathing/BreathingMainViewModel.swift
@@ -50,6 +50,7 @@ class BreathingMainViewModel: BreathingManager, ObservableObject {
         Task {
             for cycle in 1...3 {
                 activeCircle = cycle
+                showText = activeCircle < 2
                 await startBreathingPhase()
             }
             isBreathingCompleted = true


### PR DESCRIPTION
## 🔥 작업한 내용
- 호흡뷰 인디케이터 수정 반영
- 호흡 뷰 모델 로직 추가: activeCircle 상태에 따라 텍스트가 조건적으로 표시되도록 수정 
(호흡 세션 2번째 사이클 부터는 가이드 문구가 표시되지 않도록)



## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 전체적인 UI 레이아웃 구조가 일관되게 동작하는지 의견 부탁드립니다.
- activeCircle 값에 따라 텍스트 표시 조건을 개선한 부분이 자연스러운지 검토 요청드립니다.


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->

https://github.com/user-attachments/assets/8ffe4f18-92f6-4d3f-94ac-b44372f0aa49





## 🚨 관련 이슈
- Resolved: #106 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
