### PR TITLE
[Fix] 호흡 화면 흰 화면 및 호흡 횟수 측정 오류

### DIFF
--- a/Spha/Shared/Managers/RouterManager.swift
+++ b/Spha/Shared/Managers/RouterManager.swift
@@ -63,10 +63,12 @@ class RouterManager: ObservableObject {
     }
 
     func backToMain() {
-        self.path = NavigationPath()
         // 상태 초기화를 알리는 Notification 전송
-        NotificationCenter.default.post(name: RouterManager.backToMainNotification, object: nil)
-        path.append(SphaView.mainView)
+        DispatchQueue.main.async { [weak self] in
+               self?.path = NavigationPath() // 초기화
+               self?.path.append(SphaView.mainView) // 메인 화면 추가
+           }
+           NotificationCenter.default.post(name: RouterManager.backToMainNotification, object: nil)
     }
     
     // 알림을 눌렀을 때 breathingMainView로 이동

--- a/Spha/Spha/Views/Breathing/BreathingMainView.swift
+++ b/Spha/Spha/Views/Breathing/BreathingMainView.swift
@@ -64,10 +64,9 @@ struct BreathingMainView<BreathViewModel>: View where BreathViewModel: Breathing
         .onAppear {
             viewModel.startBreathingIntro()
         }
-
-        .onChange(of: viewModel.isBreathingCompleted) { _, _ in
+        .onChange(of: viewModel.isBreathingCompleted) { oldValue, newValue in
+            if !newValue { return }
             router.push(view: .breathingOutroView)
-            
         }
     }
 }

--- a/Spha/Spha/Views/Breathing/BreathingOutroViewModel.swift
+++ b/Spha/Spha/Views/Breathing/BreathingOutroViewModel.swift
@@ -22,7 +22,8 @@ class BreathingOutroViewModel: ObservableObject {
             }
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
-                guard let _ = self else { return }
+                guard let self = self else { return }
+                 self.opacity = 1.0 // 복원
                 completion()
             }
         }


### PR DESCRIPTION
## 🔥 작업한 내용
- 호흡 동작이 끝나고 흰색 화면이 발생하고 횟수가 2회 측정되는 오류를 수정했습니다.
- RounterManager에서 UI작업이 메인쓰레드에서 동작하도록 DispatchQueue를 이용하고 weak self로 참조하도록 했습니다.
- BreathingMainView의 breathingCompleted 변수가 변화했을 때 하는 동작을 false에서 true로 변환할 때만 동작하도록 했습니다.


## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 알림을 이용한 화면 이동하는 부분에서 메인쓰레드에서 실행하며 약한 참조를 하고 있는데, backtoMain 메서드에서는 위와 같은 처리가 안되있어서 해봤습니다.
- 그리고 혹시 이 변수가 두 번 변화해서 값이 2회 기록되는 것인지 의심되어 분기문을 추가했더니 오류가 해결되었습니다.
- 종합 : 해결은 했지만 명확한 이유는 알지 못한 상태입니다. 참조와 ViewCycle을 깊이 있게 알아봐야 구체적인 원인을 알 수 있을 것 같습니다.
<img width="250" alt="스크린샷 2024-12-02 오후 11 21 59" src="https://github.com/user-attachments/assets/8d698e86-4106-4735-bf8e-d15168b56051">


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->

https://github.com/user-attachments/assets/d87c8545-3cee-4279-9060-473fa9e6792e



## 🚨 관련 이슈
- Resolved: #105


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
