### PR TITLE
[Fix] 통계뷰 스와이프 버그 픽스

### DIFF
--- a/Spha/Shared/Managers/RouterManager.swift
+++ b/Spha/Shared/Managers/RouterManager.swift
@@ -16,6 +16,7 @@ class RouterManager: ObservableObject {
     static let goToBreathingNotification = Notification.Name("goToBreathingNotification")
     
     init() {
+        path = NavigationPath()
         // Notification 구독
         NotificationCenter.default.addObserver(
             self,

--- a/Spha/Spha.xcodeproj/project.pbxproj
+++ b/Spha/Spha.xcodeproj/project.pbxproj
@@ -872,7 +872,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Spha/Preview Content\"";
-				DEVELOPMENT_TEAM = 6FFZZTFJHB;
+				DEVELOPMENT_TEAM = 2WSJ3W54FF;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Spha/Info.plist;
@@ -890,7 +890,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.sophia5.Spha;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sophia1.Spha;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -914,7 +914,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Spha/Preview Content\"";
-				DEVELOPMENT_TEAM = 6FFZZTFJHB;
+				DEVELOPMENT_TEAM = 2WSJ3W54FF;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Spha/Info.plist;
@@ -932,7 +932,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.sophia5.Spha;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sophia1.Spha;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -954,7 +954,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SphaWatch Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = 6FFZZTFJHB;
+				DEVELOPMENT_TEAM = 2WSJ3W54FF;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "SphaWatch-Watch-App-Info.plist";
@@ -964,14 +964,14 @@
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "\"앱에서 심박수 변동성(HRV)을 기록하고 분석하기 위해 HealthKit 데이터를 사용합니다.\"";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "\"앱에서 심박수 변동성(HRV)을 기록하고 분석하기 위해 HealthKit 데이터를 사용합니다.\"";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.sophia5.Spha;
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.sophia1.Spha;
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.sophia5.Spha.watchkitapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sophia1.Spha.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -991,7 +991,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SphaWatch Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = 6FFZZTFJHB;
+				DEVELOPMENT_TEAM = 2WSJ3W54FF;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "SphaWatch-Watch-App-Info.plist";
@@ -1001,14 +1001,14 @@
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "\"앱에서 심박수 변동성(HRV)을 기록하고 분석하기 위해 HealthKit 데이터를 사용합니다.\"";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "\"앱에서 심박수 변동성(HRV)을 기록하고 분석하기 위해 HealthKit 데이터를 사용합니다.\"";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.sophia5.Spha;
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.sophia1.Spha;
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.sophia5.Spha.watchkitapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sophia1.Spha.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;

--- a/Spha/Spha/Views/Statistics/DailyStatisticsView.swift
+++ b/Spha/Spha/Views/Statistics/DailyStatisticsView.swift
@@ -26,6 +26,9 @@ struct DailyStatisticsView: View {
             .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
             .frame(maxHeight: 56)
             .padding(.horizontal, 24)
+            .onChange(of: viewModel.selectedDate) { _, newDate in
+                viewModel.updateDates(for: newDate)
+            }
             
             // 일별 통계 TabView
             TabView(selection: $viewModel.currentDate) {
@@ -35,32 +38,8 @@ struct DailyStatisticsView: View {
                 }
             }
             .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-            .onChange(of: viewModel.currentDate) { newDate in
-                // 현재 날짜가 속한 주의 날짜들 확인
-                if let currentWeek = viewModel.weeks.first(where: { week in
-                    week.contains(where: { date in
-                        Calendar.current.isDate(date, inSameDayAs: newDate)
-                    })
-                }) {
-                    viewModel.selectedDate = currentWeek[0]
-                } else {
-                    // 현재 주에 없는 날짜라면 새로운 주 로드
-                    let newWeek = viewModel.getWeekForDate(newDate)
-                    if newDate < viewModel.weeks.first![0] {
-                        viewModel.weeks.insert(newWeek, at: 0)
-                        viewModel.selectedDate = newWeek[0]
-                    } else {
-                        viewModel.weeks.append(newWeek)
-                        viewModel.selectedDate = newWeek[0]
-                    }
-                }
-                
-                // 추가 날짜 로드
-                if newDate == viewModel.availableDates.first {
-                    viewModel.loadPreviousDay()
-                } else if newDate == viewModel.availableDates.last {
-                    viewModel.loadNextDay()
-                }
+            .onChange(of: viewModel.currentDate) { _, newDate in
+                viewModel.updateDates(for: newDate)
             }
         }
         .background(Color.black)

--- a/Spha/Spha/Views/Statistics/DailyStatisticsViewModel.swift
+++ b/Spha/Spha/Views/Statistics/DailyStatisticsViewModel.swift
@@ -58,22 +58,33 @@ class DailyStatisticsViewModel: ObservableObject {
         self.healthKitManager = HealthKitManager()
         self.mindfulSessionManager = MindfulSessionManager()
         
+        // 현재 주만 초기화
         let thisWeek = getCurrentWeek()
-        let lastWeek = getWeekForDate(calendar.date(byAdding: .weekOfYear, value: -1, to: Date())!)
-        let nextWeek = getWeekForDate(calendar.date(byAdding: .weekOfYear, value: 1, to: Date())!)
-        weeks = [lastWeek, thisWeek, nextWeek]
+        weeks = [thisWeek]
+        selectedDate = thisWeek[0]
         
         initializeAvailableDates()
-        selectedDate = thisWeek[0]
+        loadPreviousWeek() // 초기에 이전 주 하나 로드
         
         updateDailyRecord()
     }
     
     // MARK: - 날짜 관리
     private func initializeAvailableDates() {
-        availableDates = (-7...7).compactMap { offset in
-            calendar.date(byAdding: .day, value: offset, to: currentDate)
-        }.filter { $0 <= Date() }
+        // 현재 주의 모든 날짜를 포함하도록 초기화
+        let currentWeekDates = getCurrentWeekDates()
+        availableDates = currentWeekDates.filter { $0 <= Date() }
+        
+        // 이전 주의 날짜들도 미리 로드
+        if let mondayOfCurrentWeek = currentWeekDates.first {
+            let previousWeekDates = (-7...0).compactMap { offset in
+                calendar.date(byAdding: .day, value: offset, to: mondayOfCurrentWeek)
+            }
+            availableDates = (previousWeekDates + availableDates).filter { $0 <= Date() }
+        }
+        
+        // 중복 제거 및 정렬
+        availableDates = Array(Set(availableDates)).sorted()
     }
     
     func loadPreviousDay() {
@@ -133,10 +144,22 @@ class DailyStatisticsViewModel: ObservableObject {
         guard let firstWeekMonday = weeks.first?.first else { return }
         let previousMonday = calendar.date(byAdding: .weekOfYear, value: -1, to: firstWeekMonday)!
         
-        let newWeek = (0..<7).compactMap { dayOffset in
-            calendar.date(byAdding: .day, value: dayOffset, to: previousMonday)
+        // 9월 1일 이전의 주는 로드하지 않음
+        guard previousMonday >= startDate else { return }
+        
+        let newWeek = getWeekForDate(previousMonday)
+        
+        // 중복 체크 후 추가
+        if !weeks.contains(where: { week in
+            calendar.isDate(week[0], equalTo: newWeek[0], toGranularity: .day)
+        }) {
+            weeks.insert(newWeek, at: 0)
+            
+            // 이전 주의 날짜들을 availableDates에도 추가
+            let newDates = newWeek.filter { $0 <= Date() && $0 >= startDate }
+            availableDates.insert(contentsOf: newDates, at: 0)
+            availableDates = Array(Set(availableDates)).sorted() // 중복 제거 및 정렬
         }
-        weeks.insert(newWeek, at: 0)
     }
     
     func handleDateTap(_ date: Date) {
@@ -154,6 +177,65 @@ class DailyStatisticsViewModel: ObservableObject {
             return currentWeek
         }
         return []
+    }
+    
+    func updateDates(for newDate: Date) {
+        guard newDate <= Date() else { return }
+        
+        // 현재 날짜가 속한 주 찾기
+        if let currentWeek = weeks.first(where: { week in
+            week.contains { date in
+                calendar.isDate(date, inSameDayAs: newDate)
+            }
+        }) {
+            selectedDate = currentWeek[0]
+            currentDate = newDate
+            
+            // 날짜가 첫 번째 주에 속하면 이전 주 로드
+            if currentWeek[0] == weeks.first?[0] {
+                loadPreviousWeek()
+            }
+        } else {
+            // 새로운 주 로드가 필요한 경우
+            let newWeek = getWeekForDate(newDate)
+            
+            if newDate < (weeks.first?[0] ?? Date()) {
+                weeks.insert(newWeek, at: 0)
+                selectedDate = newWeek[0]
+                currentDate = newDate
+                
+                // 이전 주 미리 로드
+                loadPreviousWeek()
+                
+                // availableDates 업데이트
+                let newDates = newWeek.filter { $0 <= Date() }
+                availableDates.insert(contentsOf: newDates, at: 0)
+                availableDates = Array(Set(availableDates)).sorted()
+            }
+        }
+        
+        // 연속된 날짜 데이터 보장
+        ensureContiguousDates(around: newDate)
+    }
+    
+    // 새로 추가: 연속된 날짜 데이터 보장
+    private func ensureContiguousDates(around date: Date) {
+        let calendar = Calendar.current
+        
+        // 현재 날짜 기준 이전 7일만 확인
+        let dateRange = (-7...0).compactMap { offset in
+            calendar.date(byAdding: .day, value: offset, to: date)
+        }.filter { $0 <= Date() && $0 >= startDate }
+        
+        // 없는 날짜 추가
+        for date in dateRange {
+            if !availableDates.contains(where: { calendar.isDate($0, inSameDayAs: date) }) {
+                availableDates.append(date)
+            }
+        }
+        
+        // 정렬
+        availableDates = Array(Set(availableDates)).sorted()
     }
     
     // MARK: - HRV 데이터 처리
@@ -216,6 +298,12 @@ class DailyStatisticsViewModel: ObservableObject {
         return calendar.date(from: components)!
     }
     
+    // 시작 날짜를 2024년 9월 1일로 설정
+    private var startDate: Date {
+        let components = DateComponents(year: 2024, month: 9, day: 1)
+        return calendar.date(from: components)!
+    }
+    
     var currentMonthOffset: Int {
         let startDate = calendar.date(byAdding: .month, value: -50, to: currentMonth)!
         let components = calendar.dateComponents([.month], from: startDate, to: Date())
@@ -223,9 +311,20 @@ class DailyStatisticsViewModel: ObservableObject {
     }
     
     func getCalendarMonths() -> [Date] {
-        (-3...1).compactMap { monthOffset in
-            calendar.date(byAdding: .month, value: monthOffset, to: currentMonth)
+        // 시작 날짜(9월)부터 현재 날짜의 다음 달까지의 모든 달을 생성
+        var dates: [Date] = []
+        var currentDate = startDate
+        
+        // 현재 달의 다음 달까지 생성
+        let endDate = calendar.date(byAdding: .month, value: 1, to: currentMonth)!
+        
+        while currentDate <= endDate {
+            dates.append(currentDate)
+            guard let nextMonth = calendar.date(byAdding: .month, value: 1, to: currentDate) else { break }
+            currentDate = nextMonth
         }
+        
+        return dates
     }
     
     func getDaysInMonthStartingMonday(for date: Date) -> [(offset: Int, element: Date?)] {

--- a/Spha/Spha/Views/Statistics/DailyStatisticsViewModel.swift
+++ b/Spha/Spha/Views/Statistics/DailyStatisticsViewModel.swift
@@ -197,31 +197,8 @@ class DailyStatisticsViewModel: ObservableObject {
                 availableDates = Array(Set(availableDates)).sorted()
             }
         }
-        
-        // 연속된 날짜 데이터 보장
-        ensureContiguousDates(around: newDate)
     }
-    
-    // 새로 추가: 연속된 날짜 데이터 보장
-    private func ensureContiguousDates(around date: Date) {
-        let calendar = Calendar.current
         
-        // 현재 날짜 기준 이전 7일만 확인
-        let dateRange = (-7...0).compactMap { offset in
-            calendar.date(byAdding: .day, value: offset, to: date)
-        }.filter { $0 <= Date() && $0 >= startDate }
-        
-        // 없는 날짜 추가
-        for date in dateRange {
-            if !availableDates.contains(where: { calendar.isDate($0, inSameDayAs: date) }) {
-                availableDates.append(date)
-            }
-        }
-        
-        // 정렬
-        availableDates = Array(Set(availableDates)).sorted()
-    }
-    
     // MARK: - HRV 데이터 처리
     private func updateDailyRecord() {
         healthKitManager.fetchDailyHRV(for: currentDate) { [weak self] samples, hrvError in

--- a/Spha/Spha/Views/Statistics/DailyStatisticsViewModel.swift
+++ b/Spha/Spha/Views/Statistics/DailyStatisticsViewModel.swift
@@ -87,22 +87,6 @@ class DailyStatisticsViewModel: ObservableObject {
         availableDates = Array(Set(availableDates)).sorted()
     }
     
-    func loadPreviousDay() {
-        guard let firstDate = availableDates.first else { return }
-        if let newDate = calendar.date(byAdding: .day, value: -1, to: firstDate) {
-            availableDates.insert(newDate, at: 0)
-        }
-    }
-    
-    func loadNextDay() {
-        guard let lastDate = availableDates.last else { return }
-        if let newDate = calendar.date(byAdding: .day, value: 1, to: lastDate) {
-            if newDate <= Date() {
-                availableDates.append(newDate)
-            }
-        }
-    }
-    
     func getCurrentWeek() -> [Date] {
         let weekday = calendar.component(.weekday, from: currentDate)
         let mondayOffset = weekday == 1 ? -6 : 2 - weekday
@@ -302,12 +286,6 @@ class DailyStatisticsViewModel: ObservableObject {
     private var startDate: Date {
         let components = DateComponents(year: 2024, month: 9, day: 1)
         return calendar.date(from: components)!
-    }
-    
-    var currentMonthOffset: Int {
-        let startDate = calendar.date(byAdding: .month, value: -50, to: currentMonth)!
-        let components = calendar.dateComponents([.month], from: startDate, to: Date())
-        return components.month ?? 0
     }
     
     func getCalendarMonths() -> [Date] {


### PR DESCRIPTION
## 🔥 작업한 내용
- 날짜 스와이프 버그 수정
  - View의 복잡한 날짜 변경 로직을 ViewModel의 updateDates 메서드로 통합
  - View에서 이전/다음 날짜 로드 로직 제거하고 ViewModel로 이동
- 날짜 관리 로직 개선
  - 날짜 초기화 로직을 현재 주와 이전 주만 포함하도록 개선
  - 데이터 시작일을 2024년 9월 1일로 설정


## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- View의 onChange 핸들러를 단순화하여 스와이프 동작 버그 수정
  -  ViewModel의 updateDates로 로직을 이동하여 단순화

## 🚨 관련 이슈
- Resolved: #126 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
