### PR TITLE
[Feat] add refresh button

### DIFF
--- a/Spha/Spha/Views/Home/MainView.swift
+++ b/Spha/Spha/Views/Home/MainView.swift
@@ -27,12 +27,13 @@ struct MainView: View {
                         } label: {
                             Image(systemName: "chart.bar.fill")
                                 .resizable()
-                                .frame(width: 28, height: 20)
+                                .frame(width: 28, height: 22)
                                 .foregroundStyle(Color.buttonGraph)
                         }
                         .padding(.trailing, 8)
                     }
                     .padding(.top, 32)
+                    .padding(.bottom, 24)
                     .padding(.horizontal, 16)
                     
                     Spacer()
@@ -60,13 +61,13 @@ struct MainView: View {
                                 .white : Color.gray0
                         )
                         .bold()
-                        .padding(.top, 8)
+                        .padding(.top, 16)
                     
                     Spacer()
                     
                     MP4PlayerView(videoURLString: viewModel.mindDustLevel)
                         .frame(width: 300, height: 300)
-                        .padding(.bottom, 16)
+                        .padding(.bottom, 32)
                     
                     
                     HStack{
@@ -113,7 +114,7 @@ struct MainView: View {
                                 .foregroundStyle(.gray)
                         }
                     }
-                    .padding(.bottom, 12)
+                    //.padding(.bottom, 12)
                     
                     Spacer()
                     

--- a/Spha/Spha/Views/Home/MainView.swift
+++ b/Spha/Spha/Views/Home/MainView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct MainView: View {
     @EnvironmentObject var router: RouterManager
+    @Environment(\.scenePhase) private var scenePhase
+    
     @StateObject private var viewModel = MainViewModel(HealthKitManager(), MindfulSessionManager())
     
     @State private var introOpacity = 0.0
@@ -124,7 +126,7 @@ struct MainView: View {
                             .frame(width: 90, height: 90)
                             .foregroundStyle(.gray)
                     }
-                    .padding(.top, 40)
+                    .padding(.top, 48)
                 }
             }
             .refreshable {
@@ -155,6 +157,11 @@ struct MainView: View {
         }
         .onChange(of: self.isFirstLaunch) { oldValue, newValue in
             viewModel.updateTodayRecord()
+        }
+        .onChange(of: scenePhase) { _, newPhase in // 추가: 앱 상태 변화 감지
+            if newPhase == .active { // 포그라운드로 복귀 시
+                viewModel.updateTodayRecord()
+            }
         }
     }
     

--- a/Spha/Spha/Views/Home/MainView.swift
+++ b/Spha/Spha/Views/Home/MainView.swift
@@ -7,6 +7,7 @@ struct MainView: View {
     @State private var introOpacity = 0.0
     @State private var isFirstLaunch: Bool = !UserDefaults.standard.bool(forKey: "hasLaunchedBefore")
     @State private var isBreathingViewPresented = false
+    @State private var isLoading = false
     
     var body: some View {
         ZStack {
@@ -14,119 +15,120 @@ struct MainView: View {
             Color.backgroundGB
                 .edgesIgnoringSafeArea(.all)
             
-            // 메인 화면 요소
-            VStack{
-                HStack{
+            ScrollView {
+                VStack{
+                    HStack{
+                        Spacer()
+                        
+                        Button {
+                            router.push(view: .dailyStatisticsView)
+                        } label: {
+                            Image(systemName: "chart.bar.fill")
+                                .resizable()
+                                .frame(width: 28, height: 20)
+                                .foregroundStyle(Color.buttonGraph)
+                        }
+                        .padding(.trailing, 8)
+                    }
+                    .padding(.top, 32)
+                    .padding(.horizontal, 16)
+                    
+                    Spacer()
+                    
+                    HStack{
+                        Text("현재 마음구슬 상태")
+                            .customFont(.caption_0)
+                            .foregroundStyle(.white)
+                        
+                        Button {
+                            router.push(view: .mainInfoView)
+                        } label: {
+                            Image(systemName: "info.circle")
+                                .resizable()
+                                .frame(width: 15, height: 15)
+                                .foregroundStyle(.white)
+                        }
+                        
+                    }
+                    
+                    Text("\(String(describing: viewModel.mindDustLvDescription))")
+                        .customFont(.title_1)
+                        .foregroundStyle(
+                            viewModel.isHRVRecordedToday ?
+                                .white : Color.gray0
+                        )
+                        .bold()
+                        .padding(.top, 8)
+                    
+                    Spacer()
+                    
+                    MP4PlayerView(videoURLString: viewModel.mindDustLevel)
+                        .frame(width: 300, height: 300)
+                        .padding(.bottom, 16)
+                    
+                    
+                    HStack{
+                        VStack{
+                            HStack{
+                                Text("\(viewModel.recommendedCount)")
+                                    .customFont(.title_0)
+                                    .foregroundStyle(.white)
+                                    .bold()
+                                
+                                Text("회")
+                                    .customFont(.caption_0)
+                                    .foregroundStyle(.white)
+                                    .bold()
+                            }
+                            .padding(.bottom, 2)
+                            
+                            Text("권장 청소 횟수")
+                                .customFont(.caption_1)
+                                .foregroundStyle(.gray)
+                        }
+                        
+                        Rectangle()
+                            .frame(width:1, height: 45)
+                            .foregroundStyle(.gray)
+                            .padding(.horizontal, 24)
+                        
+                        VStack{
+                            HStack{
+                                Text("\(viewModel.completedCount)")
+                                    .customFont(.title_0)
+                                    .foregroundStyle(.white)
+                                    .bold()
+                                
+                                Text("회")
+                                    .customFont(.caption_0)
+                                    .foregroundStyle(.white)
+                                    .bold()
+                            }
+                            .padding(.bottom, 2)
+                            
+                            Text("실행한 청소 횟수")
+                                .customFont(.caption_1)
+                                .foregroundStyle(.gray)
+                        }
+                    }
+                    .padding(.bottom, 12)
+                    
                     Spacer()
                     
                     Button {
-                        router.push(view: .dailyStatisticsView)
+                        isBreathingViewPresented.toggle()
                     } label: {
-                        Image(systemName: "chart.bar.fill")
+                        // 임시 버튼 라벨
+                        Image("mainButton")
                             .resizable()
-                            .frame(width: 28, height: 20)
-                            .foregroundStyle(Color.buttonGraph)
-                    }
-                    .padding(.trailing, 8)
-                }
-                .padding(.top, 16)
-                .padding(.horizontal, 16)
-                
-                Spacer()
-                
-                HStack{
-                    Text("현재 마음구슬 상태")
-                        .customFont(.caption_0)
-                        .foregroundStyle(.white)
-                    
-                    Button {
-                        router.push(view: .mainInfoView)
-                    } label: {
-                        Image(systemName: "info.circle")
-                            .resizable()
-                            .frame(width: 15, height: 15)
-                            .foregroundStyle(.white)
-                    }
-                    
-                }
-                
-                Text("\(String(describing: viewModel.mindDustLvDescription))")
-                    .customFont(.title_1)
-                    .foregroundStyle(
-                        viewModel.isHRVRecordedToday ?
-                            .white : Color.gray0
-                    )
-                    .bold()
-                    .padding(.top, 8)
-                
-                Spacer()
-                
-                MP4PlayerView(videoURLString: viewModel.mindDustLevel)
-                    .frame(width: 300, height: 300)
-                    .padding(.bottom, 16)
-                
-                
-                HStack{
-                    VStack{
-                        HStack{
-                            Text("\(viewModel.recommendedCount)")
-                                .customFont(.title_0)
-                                .foregroundStyle(.white)
-                                .bold()
-                            
-                            Text("회")
-                                .customFont(.caption_0)
-                                .foregroundStyle(.white)
-                                .bold()
-                        }
-                        .padding(.bottom, 2)
-                        
-                        Text("권장 청소 횟수")
-                            .customFont(.caption_1)
+                            .frame(width: 90, height: 90)
                             .foregroundStyle(.gray)
                     }
-                    
-                    Rectangle()
-                        .frame(width:1, height: 45)
-                        .foregroundStyle(.gray)
-                        .padding(.horizontal, 24)
-                    
-                    VStack{
-                        HStack{
-                            Text("\(viewModel.completedCount)")
-                                .customFont(.title_0)
-                                .foregroundStyle(.white)
-                                .bold()
-                            
-                            Text("회")
-                                .customFont(.caption_0)
-                                .foregroundStyle(.white)
-                                .bold()
-                        }
-                        .padding(.bottom, 2)
-                        
-                        Text("실행한 청소 횟수")
-                            .customFont(.caption_1)
-                            .foregroundStyle(.gray)
-                    }
+                    .padding(.top, 40)
                 }
-                .padding(.bottom, 12)
-                
-                Spacer()
-                
-                Button {
-                    isBreathingViewPresented.toggle()
-                    
-                } label: {
-                    // 임시 버튼 라벨
-                    Image("mainButton")
-                        .resizable()
-                        .frame(width: 90, height: 90)
-                        .foregroundStyle(.gray)
-                }
-                
-                Spacer()
-                
+            }
+            .refreshable {
+                triggerRefresh()
             }
             
             // OnboardingStartView 오버레이
@@ -135,11 +137,17 @@ struct MainView: View {
                     .transition(.opacity) // 페이드 효과
                     .zIndex(1) // 항상 최상위에 위치
             }
+            
+            // 로딩 중 프로그레스 바
+            if isLoading {
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle()).foregroundColor(.white)
+                    .background(Color.black.opacity(0.5).edgesIgnoringSafeArea(.all))
+            }
         }
         .sheet(isPresented: $isBreathingViewPresented) {
             BreathingMainView(breathManager: BreathingMainViewModel())
         }
-        
         .onAppear {
             if !isFirstLaunch {
                 viewModel.updateTodayRecord()
@@ -150,6 +158,22 @@ struct MainView: View {
         }
     }
     
+    private func triggerRefresh() {
+        // 햅틱 발생
+        let generator = UIImpactFeedbackGenerator(style: .light)
+        generator.impactOccurred()
+        
+        // 로딩 상태 활성화
+        isLoading = true
+        
+        // 데이터 업데이트 실행
+        viewModel.updateTodayRecord()
+        
+        // 로딩 상태 비활성화 (딜레이 시뮬레이션)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            isLoading = false
+        }
+    }
 }
 
 #Preview {


### PR DESCRIPTION
## 🔥 작업한 내용
- MainView 새로 고침 기능을 추가했습니다. 메인 화면을 아래로 스크롤하면 새로고침 기능이 동작합니다. 새로고침 기능은 HealthKit에 저장된 데이터를 새로 불러오는 기능을 수행하는데, 이렇게 수행해서 새로 고침되지 않는 것은

 Watch <-> HeatlhStore <-> Phone

이 사이에서 데이터 동기화되는데 시간이 걸리는 것으로 수정이 힘들어 보입니다.
(iOS와 watchOS 데이터를 연결 시키고 별도의 데이터를 실시간으로 주고 받도록 하는 방법도 있지만, 개인적으로 배꼽이 더 커지지 않나라고 생각합니다. )

- @Environment(\.scenePhase)을 이용해서 백그라운드에서 포그라운드로 진입 시에도 데이터를 새로 받아오도록 수정했습니다.

- 새로고침 기능을 추가하고 ScrollView의 영향으로 UI가 조금 바뀌어서 피그마를 보면서 비슷하게 다시 수정했습니다.

## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->

https://github.com/user-attachments/assets/ddcbacb8-1a38-4522-a0db-2f3d53c6ff46



## 🚨 관련 이슈
- Resolved: #138 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
