### PR TITLE
[Fix] 알림 버그 수정

### DIFF
--- a/Spha/Shared/Managers/HealthKitManager/AppDelegate.swift
+++ b/Spha/Shared/Managers/HealthKitManager/AppDelegate.swift
@@ -31,10 +31,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         return true
     }
     
-    func application(_ application: UIApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        healthKitManager.didUpdateHRVData()
-        completionHandler(.newData)
-    }
+//    func application(_ application: UIApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+//        healthKitManager.didUpdateHRVData()
+//        completionHandler(.newData)
+//    }
     
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         switch response.actionIdentifier {


### PR DESCRIPTION
## 🔥 작업한 내용
**- performFetchWithCompletionHandler 메서드를 AppDelegat에서 제거**
 백그라운드에서 앱이 실행 중일 때, 임의로 데이터를 추가했을 때 알림이 오지않아 추가했던 메서드로 기억합니다. 하지만 HKObserver가 등록되어 실행되고 있고, 임의로 추가하는 데이터에 대한 알림은 불필요하다고 생각하여 제거했습니다.

**- 알림 버그 분석**
⚽️ 문제 : Spha 앱에서 watchOS와 iOS 알림 동기화, HealthStore 저장 동기화와 별개로 알림이 중복적으로 오는 버그가 있습니다.
(저는 같은 앱이 2개 설치되어 있어 2개가 옵니다!)

<img src="https://github.com/user-attachments/assets/d26fc007-d804-443a-adc1-ee537251347f" width="250" />
<img src="https://github.com/user-attachments/assets/b7232c6e-6f3d-43c1-ba56-d6a4dfbdb097" width="250" />

🍗 기기 테스트 : 하루 동안 짧게 테스트 해본 결과, 개발에서 사용했던 제 기기에서는 정상적으로 작동합니다. 하지만 다른 애플워치에서 알림이 여러번 온다는 보고가 있다고 합니다.

🍉 실험 결과 : HealthKit 데이터 측정과 알림을 결합한 자료가 부족하다 생각되어서 그 동안은 실기기로 테스트를 진행하여 알림이 여러번 발생하는 EdgeCase를 찾아보려 했지만 확실한 인과관계를 찾지 못했습니다.

=> 따라서 기기 테스트를 통한 귀납으로는 원인을 찾기 어렵다고 판단했고 내부 동작에 대한 조사를 시행 했습니다.

😈 조사 결과 :
(해당 이슈와 무관하지만 알아둘만한 정보)
1. 백그라운드, killed 된 상태에서의 HealthKit에 접근 (공식 문서)
> Because the HealthKit store is encrypted, your app cannot read data from the store when the phone is locked. This means your app may not be able to access the store when it is launched in the background. However, apps can still write data to the store, even when the phone is locked. The store temporarily caches the data and saves it to the encrypted store as soon as the phone is unlocked.

- HealthStore는 암호화 되어있어 폰이 lock 되어 있을 때 접근이 불가능하다.
- Background에서 앱을 실행하고 HealthStore에 접근이 불가능하다
(앱이 데이터를 wirte하는 것은 lock 상태에서도 가능하고, HealthStore는 일시적으로 데이터를 캐시화 해서 두다가 폰이 unlock 되면 암호화된 HealthStore에 해당 데이터를 저장 한다.)
=> 애플워치를 끼고 수면을 취하고 일어나 폰을 unlock하면 수면 중 측정된 데이터 알림이 이때 오는 이유와 관련이 있다고 추정됩니다.

(현재 이슈의 유력한 후보)
2. HKObserverQuery 문제
<img width="1013" alt="스크린샷 2025-02-22 오후 7 48 46" src="https://github.com/user-attachments/assets/24b22e9d-19fa-40bf-8064-85362829038e" />
HKObserver의 definition을 보면 HKObserverQuery는 백그라운드 업데이트를 구독한 경우, 시스템이 데이터를 추가적으로 처리하거나 앱이 이를 처리 했다고 알려주기 전까지 알림을 반복적으로 보낼 수 있도록 설계되어 있다고 합니다. 그렇기 때문에 업데이트 Handler에서 데이터를 처리하지 않으면 계속해서 알림을 받게 됩니다.

=> 의문 : 데이터에 대한 알림을 재전송하는 텀이 그렇게 짧을까?
그렇게 요청하도록 설계 했을지 의문이지만, 컴퓨터 입장에서 충분히 긴 시간일 수 있고,,, 구체적인 텀에 대한 언급이 없었으므로 충분히 가능성 있다.


### 원인 및 해결 방법###
😻 원인 : 위 HKObserverQuery 정의에서 completionHandler가 호출되기 전까지 해당 메서드가 '중복 처리' 될 수 있다는 사실이 큰 단서.

 HKObserveryQuery 실행 => didUpdateHRVData() 호출 =>  알림 발생

fetchLastestHRV에서 비동기로 데이터를 가져오는 동안 아직 completionHandler가 호출되지 않았기 때문에 HKObserverQuery가 다시 호출되어 알림이 여러 번 보내질 수 있습니다.

🤡 해결 방안 :
=> 단순히 떠오른 방안 : 간단히 플래그를 추가하여 해당 메서드가 재호출 될 경우 return 처리하기
- 단일 스레드 환경에서는 유효하지만 해당 환경은 멀티쓰레드 환경우로 해당 시스템이 해당 메서드를 언제 호출하는지 정확하게 알 수 없습니다.

=> 시스템의 메서드 호출 시점이 불분명하므로 멀티 쓰레드 환경에서도 유효한 아래 동기화 기법을 고려해보았습니다.
- DispatchQueue.barrier
- NSLock
- DispatchSemaphore 

=> DispatchQueue.barrier를 사용하면 중복되는 didHRVDataUpdated 메서드의 호출을 하나의 queue에 담을 수 있습니다. 내부에서 예외처리로 중복된 작업을 방지해주고 있고, 그렇기 때문에 해당 메서드가 여러 번 실행 되더라도 순차적으로 실행된다면 문제가 없을 것이라고 예상합니다.
 NSLock의 경우 잠금 시점과 해제 시점을 개발자가 지정해줘야 하기 때문에 DispatchQueue보다 위험도가 높다고 생각했고, Semaphore의 경우 해당 문제 상황에서 여러 프로세스를 카운팅할 필요성이 없고 복잡도가 높기때문에 선택하지 않았고, DispatchQueue가 다른 방안에 비해 위험도와 복잡도가 낮다고 판단하여 선택했습니다.



## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- HKObserverQuery 정의에서 단서를 얻어 해당 해결 방안을 구현해보았습니다. 한계로는 실기기로 테스트를 해야하여 기간이 오래 걸리므로 우선 PR을 먼저 날리게 되었습니다.
- 요약하자면 시스템에 의한 중복되는 메서드 호출이 있었고, 중복되는 호출을 방지하기 위해 적절한 동기화 기법을 적용하여 한 번에 하나의 메서드만 실행되도록 보장하였습니다.

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #153 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
